### PR TITLE
fix: 🐛 semantic release defaults to repo url in package.json

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -25,6 +25,13 @@ jobs:
     steps:
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2
+        with:
+          extra_plugins: |
+            @semantic-release/changelog@5.0.1
+            @semantic-release/commit-analyzer@8.0.1
+            @semantic-release/git@9.0.0
+            @semantic-release/npm@7.0.6
+            @semantic-release/release-notes-generator@9.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/release.config.js
+++ b/release.config.js
@@ -1,7 +1,4 @@
-const packageJSON = require('./package.json');
-
 module.exports = {
-  repositoryURL: packageJSON.repository.url,
   branches: 'master',
   plugins: [
     '@semantic-release/commit-analyzer',


### PR DESCRIPTION
Also declared the sematic release plugins