### PR TITLE
fix: 🐛 reset form state during onclose event

### DIFF
--- a/src/components/SQFormDialog/SQFormDialog.css
+++ b/src/components/SQFormDialog/SQFormDialog.css
@@ -1,6 +1,0 @@
-.sqFormDialog__actions {
-  display: flex;
-  justify-content: space-between;
-  flex: 1 1 100%;
-  padding: 1.3333rem 2rem;
-}

--- a/src/components/SQFormDialog/SQFormDialog.js
+++ b/src/components/SQFormDialog/SQFormDialog.js
@@ -45,8 +45,6 @@ function SQFormDialog({
         onSave={onSave}
         saveButtonText={saveButtonText}
         title={title}
-        enableReinitialize={false}
-        initialValues={initialValues}
         muiGridProps={muiGridProps}
       />
     </Formik>

--- a/src/components/SQFormDialog/SQFormDialog.js
+++ b/src/components/SQFormDialog/SQFormDialog.js
@@ -1,21 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import Typography from '@material-ui/core/Typography';
-import Slide from '@material-ui/core/Slide';
-import Grid from '@material-ui/core/Grid';
-import {Formik, Form} from 'formik';
+import {Formik} from 'formik';
 import * as Yup from 'yup';
-import {RoundedButton} from 'scplus-shared-components';
-import SQFormButton from '../SQForm/SQFormButton';
-import './SQFormDialog.css';
-
-const Transition = React.forwardRef((props, ref) => {
-  return <Slide direction="down" ref={ref} {...props} />;
-});
+import SQFormDialogInner from './SQFormDialogInner';
 
 function SQFormDialog({
   cancelButtonText = 'Cancel',
@@ -47,43 +34,21 @@ function SQFormDialog({
       validationSchema={validationYupSchema}
       validateOnMount={true}
     >
-      <Dialog
+      <SQFormDialogInner
+        cancelButtonText={cancelButtonText}
+        children={children}
         disableBackdropClick={disableBackdropClick}
+        isDisabled={isDisabled}
+        isOpen={isOpen}
         maxWidth={maxWidth}
-        open={isOpen}
-        TransitionComponent={Transition}
         onClose={onClose}
-      >
-        <Form>
-          <DialogTitle disableTypography={true}>
-            <Typography variant="h4">{title}</Typography>
-          </DialogTitle>
-          <DialogContent dividers={true}>
-            <Grid
-              {...muiGridProps}
-              container
-              spacing={muiGridProps.spacing || 2}
-            >
-              {children}
-            </Grid>
-          </DialogContent>
-          <DialogActions className="sqFormDialog__actions">
-            <RoundedButton
-              title={cancelButtonText}
-              onClick={onClose}
-              color="secondary"
-              variant="outlined"
-            >
-              {cancelButtonText}
-            </RoundedButton>
-            {onSave && (
-              <SQFormButton title={saveButtonText}>
-                {saveButtonText}
-              </SQFormButton>
-            )}
-          </DialogActions>
-        </Form>
-      </Dialog>
+        onSave={onSave}
+        saveButtonText={saveButtonText}
+        title={title}
+        enableReinitialize={false}
+        initialValues={initialValues}
+        muiGridProps={muiGridProps}
+      />
     </Formik>
   );
 }

--- a/src/components/SQFormDialog/SQFormDialogInner.js
+++ b/src/components/SQFormDialog/SQFormDialogInner.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+  Grid,
+  Slide,
+  makeStyles
+} from '@material-ui/core';
+import {Form} from 'formik';
+import {RoundedButton} from 'scplus-shared-components';
+import {useSQFormContext} from '../../index';
+import SQFormButton from '../SQForm/SQFormButton';
+
+const Transition = React.forwardRef((props, ref) => {
+  return <Slide direction="down" ref={ref} {...props} />;
+});
+
+const useActionsStyles = makeStyles({
+  root: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    flex: '1 1 100%',
+    padding: '16px 24px'
+  }
+});
+
+function SQFormDialogInner({
+  cancelButtonText,
+  children,
+  disableBackdropClick,
+  isDisabled,
+  isOpen,
+  maxWidth,
+  onClose,
+  onSave,
+  saveButtonText,
+  title,
+  muiGridProps
+}) {
+  const actionsClasses = useActionsStyles();
+  const {resetForm} = useSQFormContext();
+
+  const handleClose = () => {
+    resetForm();
+    onClose();
+  };
+
+  return (
+    <Dialog
+      disableBackdropClick={disableBackdropClick}
+      maxWidth={maxWidth}
+      open={isOpen}
+      TransitionComponent={Transition}
+      onClose={handleClose}
+    >
+      <Form>
+        <DialogTitle disableTypography={true}>
+          <Typography variant="h4">{title}</Typography>
+        </DialogTitle>
+        <DialogContent dividers={true}>
+          <Grid {...muiGridProps} container spacing={muiGridProps.spacing || 2}>
+            {children}
+          </Grid>
+        </DialogContent>
+        <DialogActions classes={actionsClasses}>
+          <RoundedButton
+            title={cancelButtonText}
+            onClick={handleClose}
+            color="secondary"
+            variant="outlined"
+          >
+            {cancelButtonText}
+          </RoundedButton>
+          {onSave && (
+            <SQFormButton title={saveButtonText}>{saveButtonText}</SQFormButton>
+          )}
+        </DialogActions>
+      </Form>
+    </Dialog>
+  );
+}
+
+SQFormDialogInner.propTypes = {
+  /** The secondary button text (Button located on left side of Dialog) */
+  cancelButtonText: PropTypes.string,
+  /** The content to be rendered in the dialog body */
+  children: PropTypes.node.isRequired,
+  /** If true, clicking the backdrop will not fire the onClose callback. */
+  disableBackdropClick: PropTypes.bool,
+  /** The current disabled state of the Dialog Save Button */
+  isDisabled: PropTypes.bool,
+  /** The current open/closed state of the Dialog */
+  isOpen: PropTypes.bool.isRequired,
+  /** Determine the max-width of the dialog. The dialog width grows with the size of the screen. Set to false to disable maxWidth. */
+  maxWidth: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', false]),
+  /** Callback function invoked when the user clicks on the secondary button or outside the Dialog */
+  onClose: PropTypes.func.isRequired,
+  /** Callback function invoke when the user clicks the primary button */
+  onSave: PropTypes.func,
+  /** The primary button text (Button located on right side of Dialog) */
+  saveButtonText: PropTypes.string,
+  /** Title text at the top of the Dialog */
+  title: PropTypes.string.isRequired,
+  /** Any prop from https://material-ui.com/api/grid */
+  muiGridProps: PropTypes.object
+};
+
+export default SQFormDialogInner;


### PR DESCRIPTION
We need to reset the form state when we 'cancel' out of the dialog, so I moved most of the dialog into another custom component, enabling access to `resetForm` from `useSQFormContext`, and put that inside a handler. Additionally, I noticed a small issue when consuming this component re: the DialogActions styles. We weren't getting the `space-between` override we set in CSS, so I moved that to a `classes` object to directly change the MuiDialogActions-root class.

[Loom](https://www.loom.com/share/54bc957125b64fdf8bafbea15ac3f7bd)