### PR TITLE
Fix/issue 30

### DIFF
--- a/src/components/SQForm/SQFormMultiSelect.js
+++ b/src/components/SQForm/SQFormMultiSelect.js
@@ -30,6 +30,18 @@ const MenuProps = {
   getContentAnchorEl: null
 };
 
+const getToolTipTitle = (formikFieldValue, options) => {
+  if (!formikFieldValue.length) {
+    return 'No value(s) selected';
+  }
+
+  return formikFieldValue
+    .map(value => {
+      return options.find(option => option.value === value).label;
+    })
+    .join(', ');
+};
+
 function SQFormMultiSelect({
   children,
   isDisabled = false,
@@ -52,7 +64,7 @@ function SQFormMultiSelect({
   });
 
   const labelID = label.toLowerCase();
-  const toolTipTitle = field.value.join(', ');
+  const toolTipTitle = getToolTipTitle(field.value, children);
 
   const getIsSelectAllChecked = value => value.includes('ALL');
   const getIsSelectNoneChecked = value => value.includes('NONE');

--- a/src/components/SQForm/SQFormMultiSelect.js
+++ b/src/components/SQForm/SQFormMultiSelect.js
@@ -10,6 +10,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import ListItemText from '@material-ui/core/ListItemText';
 import Tooltip from '@material-ui/core/Tooltip';
 import {useSQFormContext} from '../../../src';
+import {EMPTY_LABEL} from '../../utils/constants';
 import {useForm} from './useForm';
 
 /**
@@ -109,12 +110,14 @@ function SQFormMultiSelect({
    * e.g., if value is an "ID"
    */
   const getRenderValue = selected => {
-    const selectedChildren = children
+    if (!selected.length) {
+      return EMPTY_LABEL;
+    }
+
+    return children
       ?.filter(child => selected.includes(child.value))
       ?.map(child => child.label)
       ?.join(', ');
-
-    return selectedChildren;
   };
 
   return (
@@ -129,6 +132,7 @@ function SQFormMultiSelect({
       >
         <Select
           multiple
+          displayEmpty
           input={<Input disabled={isDisabled} name={name} />}
           value={field.value}
           onBlur={handleBlur}
@@ -145,14 +149,20 @@ function SQFormMultiSelect({
               value={children.length === field.value.length ? 'NONE' : 'ALL'}
             >
               <Checkbox checked={children.length === field.value.length} />
-              <ListItemText primary="Select All" />
+              <ListItemText
+                primary="Select All"
+                primaryTypographyProps={{variant: 'body2'}}
+              />
             </MenuItem>
           )}
           {children.map(option => {
             return (
               <MenuItem key={option.value} value={option.value}>
                 <Checkbox checked={field.value.includes(option.value)} />
-                <ListItemText primary={option.label} />
+                <ListItemText
+                  primary={option.label}
+                  primaryTypographyProps={{variant: 'body2'}}
+                />
               </MenuItem>
             );
           })}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,1 @@
+export const EMPTY_LABEL = '- -';


### PR DESCRIPTION
This PR closes issue #30 
✅ Closes: #30 


Bugs fixed:

* The tooltip was rendering the dropdown option values instead of the human-readable option labels
* Changes the dropdown option items typography to the body2 variant to match other dropdown typography styles
* Now renders our empty label - - when no options are selected

https://www.loom.com/share/69e0e86f25d84258b53b76ece4569dcc