### PR TITLE
fix: 🐛 Displays - - when empty, displays label instead of value

### DIFF
--- a/src/components/SQForm/SQFormDropdown.js
+++ b/src/components/SQForm/SQFormDropdown.js
@@ -8,8 +8,8 @@ import FormHelperText from '@material-ui/core/FormHelperText';
 import Grid from '@material-ui/core/Grid';
 
 import {useForm} from './useForm';
+import {EMPTY_LABEL} from '../../utils/constants';
 
-const EMPTY_LABEL = '- -';
 const EMPTY_VALUE = '';
 const EMPTY_OPTION = {label: EMPTY_LABEL, value: EMPTY_VALUE};
 
@@ -51,16 +51,26 @@ function SQFormDropdown({
     return [EMPTY_OPTION, ...children];
   }, [children, displayEmpty]);
 
+  const renderValue = value => {
+    if (value === EMPTY_VALUE) {
+      return EMPTY_LABEL;
+    }
+
+    return options.find(option => option.value === value).label;
+  };
+
   return (
     <Grid item sm={size}>
       <InputLabel id={labelID}>{label}</InputLabel>
       <Select
+        displayEmpty={true}
         input={<Input disabled={isDisabled} name={name} />}
         value={field.value}
         onBlur={handleBlur}
         onChange={handleChange}
         fullWidth={true}
         labelId={labelID}
+        renderValue={renderValue}
       >
         {options.map(option => {
           return (


### PR DESCRIPTION
When the dropdown doesn't contain a selected value the empty label - -
will render in the field. When an option is selected, the human-readable
label will render in the field instead of the value.

✅ Closes: #31

Loom: https://www.loom.com/share/8cf9891f28074d70a7429418b4e04d15