### PR TITLE
fix: 🐛 Fixed onBlur event for autocomplete and touched fields SQAH-1268

### DIFF
--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -93,7 +93,7 @@ function SQFormAutocomplete({
   size = 'auto'
 }) {
   const classes = useStyles();
-  const {setFieldValue, setTouched, values} = useFormikContext();
+  const {setFieldValue, setTouched, values, touched} = useFormikContext();
   const [{value}] = useField(name);
   const {
     fieldState: {isFieldError},
@@ -114,10 +114,10 @@ function SQFormAutocomplete({
 
   const handleAutocompleteBlur = React.useCallback(
     event => {
-      setTouched({[name]: true});
+      setTouched({...touched, ...{[name]: true}});
       onBlur && onBlur(event);
     },
-    [name, onBlur, setTouched]
+    [name, onBlur, setTouched, touched]
   );
 
   const handleAutocompleteChange = React.useCallback(


### PR DESCRIPTION
✅ Closes: #38

Spreading the touched fields with the autocomplete touched field so that we don't overwrite the existing touched fields.

Loom shows the existing bug and fix.
Loom: https://www.loom.com/share/38621828a71246e9889085446241b58a