### PR TITLE
fix: 🐛 Allow default value to be used in autocomplete component SSC-106

### DIFF
--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -105,9 +105,6 @@ function SQFormAutocomplete({
 
   const initialValue = children.find(option => {
     if (option.value === value) {
-      if (!touched.hasOwnProperty(name)) {
-        setTouched({...touched, ...{[name]: true}});
-      }
       return option;
     }
     return null;

--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -102,6 +102,17 @@ function SQFormAutocomplete({
     name,
     isRequired
   });
+
+  const initialValue = children.find(option => {
+    if (option.value === value) {
+      if (!touched.hasOwnProperty(name)) {
+        setTouched({...touched, ...{[name]: true}});
+      }
+      return option;
+    }
+    return null;
+  });
+
   const [inputValue, setInputValue] = React.useState('');
   const prevValue = usePrevious(value);
 
@@ -150,6 +161,7 @@ function SQFormAutocomplete({
         onChange={handleAutocompleteChange}
         onInputChange={handleInputChange}
         inputValue={inputValue}
+        value={initialValue}
         getOptionLabel={option => option.label}
         renderInput={params => {
           return (

--- a/src/components/SQForm/useForm.js
+++ b/src/components/SQForm/useForm.js
@@ -22,7 +22,7 @@ export function useForm({name, isRequired, onBlur, onChange}) {
   const isTouched = getIn(meta, 'touched');
   const isError = !!errorMessage;
   const isFieldError = isTouched && isError;
-  const isFieldRequired = !isTouched && isRequired;
+  const isFieldRequired = !isTouched && isRequired && !getIn(meta, 'value');
   const isFulfilled = isTouched && !isFieldError;
 
   const handleChange = React.useCallback(

--- a/stories/SQForm.stories.js
+++ b/stories/SQForm.stories.js
@@ -59,7 +59,7 @@ const MOCK_FORM_ENTITY = {
 };
 
 const MOCK_ACTIONS_FORM_ENTITY = {
-  actions: '',
+  actions: 2,
   note: ''
 };
 
@@ -515,7 +515,7 @@ export const applyAnAction = () => {
       >
         <SQFormAutocomplete
           name="actions"
-          label="Actions"
+          label="Actions with a default value"
           size={5}
           isRequired={true}
         >


### PR DESCRIPTION
✅ Closes: #43

We can now pass a default value to the autocomplete component.  It also sets the touched property to true so the field shows as valid and not still required.

Loom: https://www.loom.com/share/6c16a4ca15364c6f9871b953d0a0a994