### PR TITLE
feat: 🎸 Allow text fields HTML5 types

### DIFF
--- a/src/components/SQForm/SQFormTextField.js
+++ b/src/components/SQForm/SQFormTextField.js
@@ -16,7 +16,8 @@ function SQFormTextField({
   onBlur,
   onChange,
   startAdornment,
-  endAdornment
+  endAdornment,
+  type = 'text'
 }) {
   const {
     formikField: {field},
@@ -47,7 +48,7 @@ function SQFormTextField({
         }}
         FormHelperTextProps={{error: isFieldError}}
         name={name}
-        type="text"
+        type={type}
         label={label}
         helperText={HelperTextComponent}
         placeholder={placeholder}
@@ -80,7 +81,9 @@ SQFormTextField.propTypes = {
   /** Adornment that appears at the start of the input */
   startAdornment: PropTypes.node,
   /** Adornment that appears at the end of the input */
-  endAdornment: PropTypes.node
+  endAdornment: PropTypes.node,
+  /** Defines the input type for the text field. Must be a valid HTML5 input type */
+  type: PropTypes.string
 };
 
 export default SQFormTextField;

--- a/stories/SQForm.stories.js
+++ b/stories/SQForm.stories.js
@@ -135,7 +135,7 @@ export const basicForm = () => {
           {MOCK_AUTOCOMPLETE_OPTIONS}
         </SQFormAutocomplete>
         <SQFormTextField name="hobby" label="Hobby" size={4} />
-        <SQFormTextField name="age" label="Age" size={2} />
+        <SQFormTextField name="age" label="Age" type="number" size={2} />
         <SQFormDropdown name="state" label="State" displayEmpty={true} size={4}>
           {MOCK_STATE_OPTIONS}
         </SQFormDropdown>
@@ -208,7 +208,13 @@ export const formWithValidation = () => {
         >
           {MOCK_STATE_OPTIONS}
         </SQFormDropdown>
-        <SQFormTextField name="age" label="Age" size={2} isRequired={true} />
+        <SQFormTextField
+          name="age"
+          label="Age"
+          type="number"
+          size={2}
+          isRequired={true}
+        />
         <SQFormTextarea name="note" label="Note" size={5} isRequired={true} />
         <Grid item sm={12}>
           <Grid container justify="space-between">


### PR DESCRIPTION
Allow a HTML5 types to be supplied to SQForm text fields

You can now pass a string for prop `type` to give the the input under SQFormTextField a HTML5 input type

✅ Closes: #45

Loom: https://www.loom.com/share/cc3f1322e3e44ea385f1b978f1bcc935