### PR TITLE
feat: 🎸 allow passthrough of props to mui field children

### DIFF
--- a/src/components/SQForm/SQFormCheckbox.js
+++ b/src/components/SQForm/SQFormCheckbox.js
@@ -11,7 +11,8 @@ function SQFormCheckbox({
   label,
   name,
   onChange,
-  size = 'auto'
+  size = 'auto',
+  muiFieldProps = {}
 }) {
   const {
     formikField: {field},
@@ -32,6 +33,7 @@ function SQFormCheckbox({
             disabled={isDisabled}
             name={name}
             onChange={handleChange}
+            {...muiFieldProps}
           />
         }
         label={label}
@@ -50,7 +52,9 @@ SQFormCheckbox.propTypes = {
   /** Custom onChange event callback */
   onChange: PropTypes.func,
   /** Size of the input given full-width is 12. */
-  size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+  size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  muiFieldProps: PropTypes.object
 };
 
 export default SQFormCheckbox;

--- a/src/components/SQForm/SQFormCheckbox.js
+++ b/src/components/SQForm/SQFormCheckbox.js
@@ -53,7 +53,7 @@ SQFormCheckbox.propTypes = {
   onChange: PropTypes.func,
   /** Size of the input given full-width is 12. */
   size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  /** Any valid prop for material ui checkbox child component - https://material-ui.com/api/checkbox/#props */
   muiFieldProps: PropTypes.object
 };
 

--- a/src/components/SQForm/SQFormDatePicker.js
+++ b/src/components/SQForm/SQFormDatePicker.js
@@ -24,7 +24,8 @@ function SQFormDatePicker({
   isRequired = false,
   placeholder = '',
   onBlur,
-  onChange
+  onChange,
+  muiFieldProps = {}
 }) {
   const {
     formikField: {field, helpers},
@@ -73,6 +74,7 @@ function SQFormDatePicker({
             />
           );
         }}
+        {...muiFieldProps}
       />
     </Grid>
   );
@@ -94,7 +96,9 @@ SQFormDatePicker.propTypes = {
   /** Custom onBlur event callback */
   onBlur: PropTypes.func,
   /** Custom onChange event callback */
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  muiFieldProps: PropTypes.object
 };
 
 export default SQFormDatePicker;

--- a/src/components/SQForm/SQFormDatePicker.js
+++ b/src/components/SQForm/SQFormDatePicker.js
@@ -97,7 +97,7 @@ SQFormDatePicker.propTypes = {
   onBlur: PropTypes.func,
   /** Custom onChange event callback */
   onChange: PropTypes.func,
-  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  /** Any valid prop for material ui datepicker child component - https://material-ui.com/components/pickers/  */
   muiFieldProps: PropTypes.object
 };
 

--- a/src/components/SQForm/SQFormDateTimePicker.js
+++ b/src/components/SQForm/SQFormDateTimePicker.js
@@ -24,7 +24,8 @@ function SQFormDateTimePicker({
   isRequired = false,
   placeholder = '',
   onBlur,
-  onChange
+  onChange,
+  muiFieldProps = {}
 }) {
   const {
     formikField: {field, helpers},
@@ -73,6 +74,7 @@ function SQFormDateTimePicker({
             />
           );
         }}
+        {...muiFieldProps}
       />
     </Grid>
   );
@@ -94,7 +96,9 @@ SQFormDateTimePicker.propTypes = {
   /** Custom onBlur event callback */
   onBlur: PropTypes.func,
   /** Custom onChange event callback */
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  muiFieldProps: PropTypes.object
 };
 
 export default SQFormDateTimePicker;

--- a/src/components/SQForm/SQFormDateTimePicker.js
+++ b/src/components/SQForm/SQFormDateTimePicker.js
@@ -97,7 +97,7 @@ SQFormDateTimePicker.propTypes = {
   onBlur: PropTypes.func,
   /** Custom onChange event callback */
   onChange: PropTypes.func,
-  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  /** Any valid prop for material ui datetimepicker child component - https://material-ui.com/components/pickers/  */
   muiFieldProps: PropTypes.object
 };
 

--- a/src/components/SQForm/SQFormDropdown.js
+++ b/src/components/SQForm/SQFormDropdown.js
@@ -22,7 +22,8 @@ function SQFormDropdown({
   name,
   onBlur,
   onChange,
-  size = 'auto'
+  size = 'auto',
+  muiFieldProps = {}
 }) {
   const {
     formikField: {field},
@@ -71,6 +72,7 @@ function SQFormDropdown({
         fullWidth={true}
         labelId={labelID}
         renderValue={renderValue}
+        {...muiFieldProps}
       >
         {options.map(option => {
           return (
@@ -110,7 +112,9 @@ SQFormDropdown.propTypes = {
   /** Custom onChange event callback */
   onChange: PropTypes.func,
   /** Size of the input given full-width is 12. */
-  size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+  size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  muiFieldProps: PropTypes.object
 };
 
 export default SQFormDropdown;

--- a/src/components/SQForm/SQFormDropdown.js
+++ b/src/components/SQForm/SQFormDropdown.js
@@ -113,7 +113,7 @@ SQFormDropdown.propTypes = {
   onChange: PropTypes.func,
   /** Size of the input given full-width is 12. */
   size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  /** Any valid prop for material ui select child component - https://material-ui.com/api/select/#props  */
   muiFieldProps: PropTypes.object
 };
 

--- a/src/components/SQForm/SQFormMultiSelect.js
+++ b/src/components/SQForm/SQFormMultiSelect.js
@@ -51,7 +51,8 @@ function SQFormMultiSelect({
   name,
   size = 'auto',
   useSelectAll = true,
-  toolTipPlacement = 'bottom'
+  toolTipPlacement = 'bottom',
+  muiFieldProps = {}
 }) {
   const {setFieldValue} = useSQFormContext();
   const [toolTipEnabled, setToolTipEnabled] = React.useState(true);
@@ -143,6 +144,7 @@ function SQFormMultiSelect({
           MenuProps={MenuProps}
           onOpen={toggleTooltip}
           onClose={toggleTooltip}
+          {...muiFieldProps}
         >
           {useSelectAll && (
             <MenuItem
@@ -196,7 +198,9 @@ SQFormMultiSelect.propTypes = {
   /** This property will allow the end user to check a "Select All" box */
   useSelectAll: PropTypes.bool,
   /** Use MUI's Tooltip Position Values */
-  toolTipPlacement: PropTypes.string
+  toolTipPlacement: PropTypes.string,
+  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  muiFieldProps: PropTypes.object
 };
 
 export default SQFormMultiSelect;

--- a/src/components/SQForm/SQFormMultiSelect.js
+++ b/src/components/SQForm/SQFormMultiSelect.js
@@ -199,7 +199,7 @@ SQFormMultiSelect.propTypes = {
   useSelectAll: PropTypes.bool,
   /** Use MUI's Tooltip Position Values */
   toolTipPlacement: PropTypes.string,
-  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  /** Any valid prop for material ui select child component - https://material-ui.com/api/select/#props  */
   muiFieldProps: PropTypes.object
 };
 

--- a/src/components/SQForm/SQFormReadOnlyField.js
+++ b/src/components/SQForm/SQFormReadOnlyField.js
@@ -4,7 +4,7 @@ import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
 import {useForm} from './useForm';
 
-function SQFormReadOnlyField({label, name, size = 'auto'}) {
+function SQFormReadOnlyField({label, name, size = 'auto', muiFieldProps = {}}) {
   const {
     formikField: {field}
   } = useForm({name, isRequired: false});
@@ -22,6 +22,7 @@ function SQFormReadOnlyField({label, name, size = 'auto'}) {
           disableUnderline: true
         }}
         style={{marginBottom: 21}}
+        {...muiFieldProps}
       />
     </Grid>
   );
@@ -33,7 +34,9 @@ SQFormReadOnlyField.propTypes = {
   /** Name of the field will be the Object key of the key/value pair form payload */
   name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Size of the input given full-width is 12. */
-  size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+  size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  muiFieldProps: PropTypes.object
 };
 
 export default SQFormReadOnlyField;

--- a/src/components/SQForm/SQFormReadOnlyField.js
+++ b/src/components/SQForm/SQFormReadOnlyField.js
@@ -35,7 +35,7 @@ SQFormReadOnlyField.propTypes = {
   name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Size of the input given full-width is 12. */
   size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  /** Any valid prop for material ui text input child component - https://material-ui.com/api/text-field/#props */
   muiFieldProps: PropTypes.object
 };
 

--- a/src/components/SQForm/SQFormTextField.js
+++ b/src/components/SQForm/SQFormTextField.js
@@ -17,7 +17,8 @@ function SQFormTextField({
   onChange,
   startAdornment,
   endAdornment,
-  type = 'text'
+  type = 'text',
+  muiFieldProps = {}
 }) {
   const {
     formikField: {field},
@@ -56,6 +57,7 @@ function SQFormTextField({
         onBlur={handleBlur}
         required={isRequired}
         value={field.value}
+        {...muiFieldProps}
       />
     </Grid>
   );
@@ -83,7 +85,9 @@ SQFormTextField.propTypes = {
   /** Adornment that appears at the end of the input */
   endAdornment: PropTypes.node,
   /** Defines the input type for the text field. Must be a valid HTML5 input type */
-  type: PropTypes.string
+  type: PropTypes.string,
+  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  muiFieldProps: PropTypes.object
 };
 
 export default SQFormTextField;

--- a/src/components/SQForm/SQFormTextField.js
+++ b/src/components/SQForm/SQFormTextField.js
@@ -86,7 +86,7 @@ SQFormTextField.propTypes = {
   endAdornment: PropTypes.node,
   /** Defines the input type for the text field. Must be a valid HTML5 input type */
   type: PropTypes.string,
-  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  /** Any valid prop for material ui text input child component - https://material-ui.com/api/text-field/#props */
   muiFieldProps: PropTypes.object
 };
 

--- a/src/components/SQForm/SQFormTextarea.js
+++ b/src/components/SQForm/SQFormTextarea.js
@@ -16,7 +16,8 @@ function SQFormTextarea({
   onBlur,
   onChange,
   rows = 3,
-  rowsMax = 3
+  rowsMax = 3,
+  muiFieldProps = {}
 }) {
   const {values} = useFormikContext();
   const {
@@ -50,6 +51,7 @@ function SQFormTextarea({
         rowsMax={rowsMax}
         variant="outlined"
         value={values[name]}
+        {...muiFieldProps}
       />
     </Grid>
   );
@@ -77,7 +79,9 @@ SQFormTextarea.propTypes = {
   /** Number of rows to display when multiline option is set to true. */
   rows: PropTypes.number,
   /** Maximum number of rows to display when multiline option is set to true. */
-  rowsMax: PropTypes.number
+  rowsMax: PropTypes.number,
+  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  muiFieldProps: PropTypes.object
 };
 
 export default SQFormTextarea;

--- a/src/components/SQForm/SQFormTextarea.js
+++ b/src/components/SQForm/SQFormTextarea.js
@@ -80,7 +80,7 @@ SQFormTextarea.propTypes = {
   rows: PropTypes.number,
   /** Maximum number of rows to display when multiline option is set to true. */
   rowsMax: PropTypes.number,
-  /** Any valid prop for material ui child component - https://material-ui.com/  */
+  /** Any valid prop for material ui text input child component - https://material-ui.com/api/text-field/#props */
   muiFieldProps: PropTypes.object
 };
 

--- a/stories/SQFormDialog.stories.js
+++ b/stories/SQFormDialog.stories.js
@@ -4,7 +4,7 @@ import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 import * as Yup from 'yup';
 
-import {SQFormDialog, SQFormDatePicker} from '../src';
+import {SQFormDialog, SQFormDatePicker, SQFormTextField} from '../src';
 
 export default {
   title: 'SQFormDialog',
@@ -55,6 +55,41 @@ export const sqFormDialog = () => (
     >
       <SQFormDatePicker name="startDate" label="Start Date" />
       <SQFormDatePicker name="endDate" label="End Date" />
+    </SQFormDialog>
+  </>
+);
+
+const MOCK_EMPTY_USER_STATE = {
+  firstName: '',
+  lastName: ''
+};
+
+export const sqFormDialogWithAutoFocus = () => (
+  <>
+    <h1>Click the Knobs tab below to toggle the open state of the Dialog</h1>
+    <SQFormDialog
+      isOpen={boolean('isOpen', false, 'Open/Close Dialog')}
+      isDisabled={boolean(
+        'isDisabled',
+        false,
+        'Toggle disabled state of Save Button'
+      )}
+      maxWidth="sm"
+      onClose={action('Close button clicked')}
+      onSave={handleSubmit}
+      title="Create New User"
+      initialValues={MOCK_EMPTY_USER_STATE}
+      muiGridProps={{
+        spacing: 2,
+        alignItems: 'center'
+      }}
+    >
+      <SQFormTextField
+        name="firstName"
+        label="First Name (Auto Focused)"
+        muiFieldProps={{autoFocus: true}}
+      />
+      <SQFormTextField name="lastName" label="Last Name" />
     </SQFormDialog>
   </>
 );


### PR DESCRIPTION
✅ Closes: 54

I omitted buttons and non-mui field types. My immediate use case for this will be autofocus on a text input in modal.