### PR TITLE
chore: 🤖 Fix semantic release to work with protected branches

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -20,5 +20,5 @@ jobs:
       - run: npm run build
       - run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SQ_GITHUB_ACTIONS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The Publish Github Action began failing after making the master branch
protected. This is because GITHUB_TOKEN doesn't have the required
permissions to write to protected branches. Therefor a Personal Action
Token from an admin account must be used instead.

✅ Closes: #56