### PR TITLE
feat: 🎸 SQFormTextField default placeholder '- -'

### DIFF
--- a/src/components/SQForm/SQFormTextField.js
+++ b/src/components/SQForm/SQFormTextField.js
@@ -11,7 +11,7 @@ function SQFormTextField({
   label,
   isDisabled = false,
   isRequired = false,
-  placeholder = '',
+  placeholder = '- -',
   size = 'auto',
   onBlur,
   onChange,


### PR DESCRIPTION
Added a default placeholder to SQFormTextField of '- -' so if there is
no value it'll show the placeholder by default

Loom video: https://www.loom.com/share/1ec0d7511f014acd8ef4c1ffc90eea0b

✅ Closes: 44