### PR TITLE
Issue-72-SQFormAutocomplete-missing-event-in-onInputChange

### DIFF
--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -144,7 +144,7 @@ function SQFormAutocomplete({
   const handleInputChange = React.useCallback(
     (_event, value) => {
       setInputValue(value);
-      onInputChange && onInputChange(_event, value);
+      onInputChange && onInputChange(value);
     },
     [onInputChange]
   );

--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -144,7 +144,7 @@ function SQFormAutocomplete({
   const handleInputChange = React.useCallback(
     (_event, value) => {
       setInputValue(value);
-      onInputChange && onInputChange(value);
+      onInputChange && onInputChange(_event, value);
     },
     [onInputChange]
   );

--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -144,7 +144,7 @@ function SQFormAutocomplete({
   const handleInputChange = React.useCallback(
     (_event, value) => {
       setInputValue(value);
-      onInputChange && onInputChange();
+      onInputChange && onInputChange(_event, value);
     },
     [onInputChange]
   );


### PR DESCRIPTION
Closes: [#72 ](https://github.com/SelectQuoteLabs/SQForm/issues/72)

We needed to add a handler in `SQFormAutocomplete` which will trigger on every keyPress, which was added but it is missing the event to return the entered value.
So this PR fixes that issue.

[https://www.loom.com/share/97302a634cd845d39674958f4efd82ed](https://www.loom.com/share/97302a634cd845d39674958f4efd82ed)