### PR TITLE
fix: 🐛 Next button logic to look at current step values to enabled/disabled SSC-115

### DIFF
--- a/src/components/SQFormDialogStepper/SQFormDialogStepper.js
+++ b/src/components/SQFormDialogStepper/SQFormDialogStepper.js
@@ -152,10 +152,12 @@ export function SQFormDialogStepper({
         return false;
       }
       const currentStepKeys = Object.keys(validationSchema.fields);
-      const formValues = Object.values(values).filter(val => val);
+      const stepValues = currentStepKeys.some(step => {
+        return !!values[step];
+      });
 
       if (
-        !formValues.length ||
+        !stepValues ||
         currentStepKeys.some(step => Object.keys(errors).includes(step)) ||
         !dirty
       ) {

--- a/stories/SQFormDialogStepper.stories.js
+++ b/stories/SQFormDialogStepper.stories.js
@@ -65,7 +65,7 @@ export const SQFormDialogStepperWithValidationAndHeightStyle = () => {
         `PV Rule : ${listItem.PLRule}`
       ],
       onClick: () => {
-        alert(`Account ${listItem.accountId}`);
+        console.log(`Account ${listItem.accountId}`);
       }
     }));
     return [
@@ -73,7 +73,7 @@ export const SQFormDialogStepperWithValidationAndHeightStyle = () => {
         header: 'Create a New Quote',
         id: 123,
         onClick: () => {
-          alert(`Create new account`);
+          console.log(`Create new account`);
         }
       },
       ...mappedList
@@ -90,8 +90,7 @@ export const SQFormDialogStepperWithValidationAndHeightStyle = () => {
   ];
 
   const initialValues = {
-    friends: ['Joe', 'Jane', 'Jack', 'Jill'],
-    selectAll: false
+    friends: ['Joe', 'Jane', 'Jack', 'Jill']
   };
   const names = [
     'Jim',
@@ -141,8 +140,7 @@ export const SQFormDialogStepperWithValidationAndHeightStyle = () => {
         <SQFormDialogStep
           label="Dependents"
           validationSchema={{
-            firstName: Yup.string(),
-            lastName: Yup.string()
+            friends: Yup.array()
           }}
         >
           <div style={{padding: '15px 15px 0px 15px', width: '100%'}}>
@@ -271,7 +269,8 @@ export const SQDialogStepperWithValidation = () => {
               then: Yup.number()
                 .required('Required for new account')
                 .min(100, 'Required for new account')
-            })
+            }),
+            age: Yup.string().required('Required')
           }}
         >
           <SQFormTextField
@@ -280,7 +279,7 @@ export const SQDialogStepperWithValidation = () => {
             type="number"
             label="Account ID"
           />
-          <SQFormTextField name="age" label="Age" size={2} />
+          <SQFormTextField name="age" label="Age" size={2} isRequired />
         </SQFormDialogStep>
         <SQFormDialogStep
           label="More Info"


### PR DESCRIPTION
✅ Closes: #75

Updated the next button enabled/disabled logic.  It now only looks at the current steps values to see if any have been set.  Before it was looking at all values from all steps.  

The touched property is still being set on all fields when the onSubmit is fired in the form.
If we have initial values then the next button will be enabled.

Loom https://www.loom.com/share/0def27c6e270412db50018b750deab0a