### PR TITLE
SSC-117 Updated to be linear, changed label placement, console warnings removed

### DIFF
--- a/stories/SQFormDialogStepper.stories.js
+++ b/stories/SQFormDialogStepper.stories.js
@@ -118,8 +118,7 @@ export const SQFormDialogStepperWithValidationAndHeightStyle = () => {
         }}
         fullWidth
         muiGridProps={{
-          justify: 'space-between',
-          alignItems: 'center'
+          justify: 'space-between'
         }}
         initialValues={initialValues}
         setValues={() => {
@@ -231,7 +230,6 @@ export const SQDialogStepperWithValidation = () => {
         maxWidth="md"
         muiGridProps={{
           justify: 'space-between',
-          alignItems: 'center',
           spacing: 6
         }}
         initialValues={{


### PR DESCRIPTION
* Step Number and Title needs 5-10 px space between them 
* Updated step title to be blow number
* Made stepper linear so progression only happens on Next click
* Can still move backwards via the step buttons to completed steps
Before
![image](https://user-images.githubusercontent.com/20329437/106667353-6fb6f000-656e-11eb-9269-fd7424c5b6a6.png)
AFTER
![image](https://user-images.githubusercontent.com/20329437/106667405-80676600-656e-11eb-8fb6-55b086c550d7.png)


loom: https://www.loom.com/share/cc8db538fedd4f50bed6fc2f20e2f7e8