### PR TITLE
fix: 🐛 Field is fulfilled if theres no error and theres a value

### DIFF
--- a/src/components/SQForm/useForm.js
+++ b/src/components/SQForm/useForm.js
@@ -14,11 +14,7 @@ function _handleError(name, isRequired) {
   }
 }
 
-function _getIsFulfilled(isRequired, hasValue, isError) {
-  if (!isRequired && !isError) {
-    return true;
-  }
-
+function _getIsFulfilled(hasValue, isError) {
   if (hasValue && !isError) {
     return true;
   }
@@ -33,11 +29,11 @@ function _getHasValue(meta) {
     return !!fieldValue.length;
   }
 
-  if (fieldValue) {
+  if (typeof fieldValue === 'number') {
     return true;
   }
 
-  return false;
+  return !!fieldValue ?? false;
 }
 
 export function useForm({name, isRequired, onBlur, onChange}) {
@@ -50,7 +46,7 @@ export function useForm({name, isRequired, onBlur, onChange}) {
   const isError = !!errorMessage;
   const isFieldError = isTouched && isError;
   const isFieldRequired = isRequired && !hasValue;
-  const isFulfilled = _getIsFulfilled(isRequired, hasValue, isError);
+  const isFulfilled = _getIsFulfilled(hasValue, isError);
 
   const handleChange = React.useCallback(
     event => {
@@ -85,10 +81,15 @@ export function useForm({name, isRequired, onBlur, onChange}) {
         </>
       );
     }
-    return (
-      <VerifiedIcon style={{color: 'var(--color-palmLeaf)', ...SPACE_STYLE}} />
-    );
-  }, [errorMessage, isFieldError, isFieldRequired]);
+    if (isFulfilled) {
+      return (
+        <VerifiedIcon
+          style={{color: 'var(--color-palmLeaf)', ...SPACE_STYLE}}
+        />
+      );
+    }
+    return ' '; // return something so UI space always exists
+  }, [errorMessage, isFieldError, isFieldRequired, isFulfilled]);
 
   return {
     formikField: {field, meta, helpers},

--- a/src/components/SQForm/useForm.js
+++ b/src/components/SQForm/useForm.js
@@ -33,7 +33,7 @@ function _getHasValue(meta) {
     return true;
   }
 
-  return !!fieldValue ?? false;
+  return !!fieldValue;
 }
 
 export function useForm({name, isRequired, onBlur, onChange}) {

--- a/stories/SQForm.stories.js
+++ b/stories/SQForm.stories.js
@@ -163,9 +163,9 @@ export const formWithValidation = () => {
     firstName: Yup.string().required('Required'),
     lastName: Yup.string().required('Required'),
     city: Yup.string(),
-    age: Yup.string()
-      .min(1, 'Invalid age')
-      .max(3, 'Invalid age')
+    age: Yup.number()
+      .min(1, 'Age 1-65')
+      .max(65, 'Age 1-65')
       .required('Required'),
     state: Yup.string().required('Required'),
     tenThousandOptions: Yup.string().required('Required'),


### PR DESCRIPTION
✅ Closes: #91

Loom: https://www.loom.com/share/c06513c248454d00b6690c75ad045056

Now, the fulfilled icon only appears when a field is not in an error state and a value is present.
Also fixed a bug where the value `0` (or any falsy number) in a numeric input would be treated as a non-value.