### PR TITLE
fix: 🐛 Update Formik to fix validate onmount bug fixed in 2.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12255,9 +12255,9 @@
       "dev": true
     },
     "formik": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.5.tgz",
-      "integrity": "sha512-KkOsyYmh5xsow+wlbdL9QSkqvbiHSb1RIToBKiooCFW4lyypn+ZlHGjTuuOqUWBqZaI5nCEupeI275Mo6tFBzg==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.6.tgz",
+      "integrity": "sha512-Kxk2zQRafy56zhLmrzcbryUpMBvT0tal5IvcifK5+4YNGelKsnrODFJ0sZQRMQboblWNym4lAW3bt+tf2vApSA==",
       "requires": {
         "deepmerge": "^2.1.1",
         "hoist-non-react-statics": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "homepage": "https://github.com/SelectQuoteLabs/SQForm#readme",
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
-    "formik": "^2.1.4",
+    "formik": "^2.2.6",
     "moment": "^2.29.1",
     "prop-types": "^15.7.2",
     "react-datepicker": "^2.13.0",


### PR DESCRIPTION
Updating Formik to fix bug reported here: https://github.com/formium/formik/issues/2652

I believe this will fix Issue #41 
The bug is difficult to reproduce in a static sandbox, I'll follow up with the developers who have been reporting the issue to see if this resolves the issue or not.

Leaving the issue open until I hear back from the developers reporting the issue.