### PR TITLE
feat: 🎸 Added ability to disable next in the stepper

### DIFF
--- a/src/components/SQFormDialogStepper/SQFormDialogStepper.js
+++ b/src/components/SQFormDialogStepper/SQFormDialogStepper.js
@@ -154,14 +154,14 @@ export function SQFormDialogStepper({
       return false;
     }, [errors, values, dirty]);
 
-    const submitText = isLastStep ? 'Submit' : 'Next';
+    const primaryButtonText = isLastStep ? 'Submit' : 'Next';
     return (
       <RoundedButton
         type="submit"
         isDisabled={isButtonDisabled}
-        title={submitText}
+        title={primaryButtonText}
       >
-        {submitText}
+        {primaryButtonText}
       </RoundedButton>
     );
   }

--- a/src/components/SQFormDialogStepper/SQFormDialogStepper.js
+++ b/src/components/SQFormDialogStepper/SQFormDialogStepper.js
@@ -76,6 +76,7 @@ export function SQFormDialogStepper({
   children,
   disableBackdropClick = false,
   isOpen = false,
+  isNextDisabled = false,
   maxWidth = 'sm',
   onClose,
   onSubmit,
@@ -131,6 +132,9 @@ export function SQFormDialogStepper({
     const {errors, values, dirty} = useFormikContext();
 
     const isButtonDisabled = React.useMemo(() => {
+      if (isNextDisabled) {
+        return true;
+      }
       if (!validationSchema) {
         return false;
       }
@@ -149,13 +153,15 @@ export function SQFormDialogStepper({
 
       return false;
     }, [errors, values, dirty]);
+
+    const submitText = isLastStep ? 'Submit' : 'Next';
     return (
       <RoundedButton
         type="submit"
         isDisabled={isButtonDisabled}
-        title={cancelButtonText}
+        title={submitText}
       >
-        {isLastStep ? 'Submit' : 'Next'}
+        {submitText}
       </RoundedButton>
     );
   }
@@ -257,6 +263,8 @@ SQFormDialogStepper.propTypes = {
   disableBackdropClick: PropTypes.bool,
   /** Sets the dialog to the maxWidth. */
   fullWidth: PropTypes.bool,
+  /** Disables the next/submit button */
+  isNextDisabled: PropTypes.bool,
   /** The current open/closed state of the Dialog */
   isOpen: PropTypes.bool.isRequired,
   /** Allows the initial values to be updated after initial render */


### PR DESCRIPTION
✅ Closes: #96

As a user of the stepper
I want to be able to disable the next/submit button until an API call or some other function occurs outside of the Formik context
So that I can stop users from going forward to the next step or submitting.

Loom uses local state that I added to the story.  Couldn't commit it but it was needed for the demo.
https://www.loom.com/share/8049ff6117704737b0080c52af89c0d4