### PR TITLE
fix: 🐛 add optional chaining to initial value of character counter

### DIFF
--- a/src/components/SQForm/SQFormTextField.js
+++ b/src/components/SQForm/SQFormTextField.js
@@ -37,7 +37,9 @@ function SQFormTextField({
     onChange
   });
 
-  const [valueLength, setValueLength] = React.useState(field.value.length || 0);
+  const [valueLength, setValueLength] = React.useState(
+    field.value?.length || 0
+  );
 
   const handleChange = e => {
     setValueLength(e.target.value.length);


### PR DESCRIPTION
The initial `useState` value of `valueLength` didn't account for a field's value being `undefined`. More details in the loom about why this was only happening in the "Form with Field Array" story.
https://www.loom.com/share/2df76c585e93494fa83ba0d480779d7c

✅ Closes: #105