### PR TITLE
feat: 🎸 add maxCharacters prop to SQFormTextarea

### DIFF
--- a/src/components/SQForm/SQFormTextarea.js
+++ b/src/components/SQForm/SQFormTextarea.js
@@ -17,18 +17,43 @@ function SQFormTextarea({
   onChange,
   rows = 3,
   rowsMax = 3,
+  maxCharacters,
+  inputProps = {},
   muiFieldProps = {}
 }) {
   const {values} = useFormikContext();
   const {
     fieldState: {isFieldError},
-    fieldHelpers: {handleBlur, handleChange, HelperTextComponent}
+    fieldHelpers: {
+      handleBlur,
+      handleChange: handleChangeHelper,
+      HelperTextComponent
+    }
   } = useForm({
     name,
     isRequired,
     onBlur,
     onChange
   });
+
+  const [valueLength, setValueLength] = React.useState(
+    values[name]?.length || 0
+  );
+
+  const handleChange = event => {
+    setValueLength(event.target.value.length);
+    handleChangeHelper(event);
+  };
+
+  const maxCharactersValue = inputProps.maxLength || maxCharacters;
+  const characterCounter =
+    maxCharactersValue && `: ${valueLength}/${maxCharactersValue}`;
+
+  const labelText = (
+    <span>
+      {label} {characterCounter}
+    </span>
+  );
 
   return (
     <Grid item sm={size}>
@@ -40,7 +65,7 @@ function SQFormTextarea({
         InputLabelProps={{shrink: true}}
         FormHelperTextProps={{error: isFieldError}}
         name={name}
-        label={label}
+        label={labelText}
         multiline={true}
         helperText={HelperTextComponent}
         placeholder={placeholder}
@@ -51,6 +76,10 @@ function SQFormTextarea({
         rowsMax={rowsMax}
         variant="outlined"
         value={values[name]}
+        inputProps={{
+          maxLength: maxCharacters,
+          ...inputProps
+        }}
         {...muiFieldProps}
       />
     </Grid>
@@ -78,6 +107,10 @@ SQFormTextarea.propTypes = {
   rows: PropTypes.number,
   /** Maximum number of rows to display when multiline option is set to true. */
   rowsMax: PropTypes.number,
+  /** Attributes applied to the `textarea` element */
+  inputProps: PropTypes.object,
+  /** Defines the maximum number of characters the user can enter into the field; mapped to `textarea` element `maxlength` attribute */
+  maxCharacters: PropTypes.number,
   /** Any valid prop for material ui text input child component - https://material-ui.com/api/text-field/#props */
   muiFieldProps: PropTypes.object
 };

--- a/stories/SQForm.stories.js
+++ b/stories/SQForm.stories.js
@@ -238,7 +238,13 @@ export const formWithValidation = () => {
           size={2}
           isRequired={true}
         />
-        <SQFormTextarea name="note" label="Note" size={5} isRequired={true} />
+        <SQFormTextarea
+          name="note"
+          label="Note"
+          size={5}
+          isRequired={true}
+          maxCharacters={100}
+        />
         <SQFormRadioButtonGroup
           name="preferredPet"
           groupLabel="Cat or Dog?"


### PR DESCRIPTION
✅ Closes: #104

Same as #103 but on the textarea component. For better readability I made the value of `characterCounter` a string instead of wrapping it in `<small>` because the label on the "outlined" variant is already pretty small.

![image](https://user-images.githubusercontent.com/35306025/109743664-b2cca900-7b96-11eb-99fc-c338790e9ca5.png)
