### PR TITLE
feat: 🎸 add max width to Stepper steps

### DIFF
--- a/src/components/SQFormDialogStepper/SQFormDialogStepper.js
+++ b/src/components/SQFormDialogStepper/SQFormDialogStepper.js
@@ -39,6 +39,7 @@ const useStyles = makeStyles({
   root: {
     padding: 20,
     width: '100%',
+    maxWidth: ({steps}) => `${300 * steps.length}px`,
     '& svg': {
       fontSize: 30,
       '& text': {
@@ -99,7 +100,7 @@ export function SQFormDialogStepper({
     ? Yup.object().shape(currentChild.props.validationSchema)
     : null;
 
-  const classes = useStyles();
+  const classes = useStyles({steps});
   const actionsClasses = useActionsStyles();
   const stepperClasses = useStepperStyles();
 


### PR DESCRIPTION
Adds a max width to the `Stepper` component in `SQFormDialogStepper` based on the amount of steps. This will prevent the steps from being spread really far apart when a wide dialog is used. 

https://www.loom.com/share/8cc3587e951b4188914ccdb3adb58d8f

The base width that's multiplied by the amount of steps is `300` purely because it looked good to me, obviously that can be changed. If necessary, this could easily be made more customizable with some props. 
Some potential ideas:
- `stepMaxWidth={400}`: to make the value completely customizable
- `stepMaxWidth="md"`: to mimic MUI - would need to come up with values for sm/md; false to turn off maxWidth
- `constrainStepWidth={false}`: defaults to true, turns off maxWidth if false

If any I would say `constrainStepWidth` would be the best option for the sake of consistency, that being said, I'm not yet aware of any edge cases that occur when this component is actually used in production.

✅ Closes: #67