### PR TITLE
fix: 🐛 ?? operator instead of || for grid spacing prop check

### DIFF
--- a/src/components/SQForm/SQForm.js
+++ b/src/components/SQForm/SQForm.js
@@ -43,7 +43,7 @@ function SQForm({
             <Grid
               {...muiGridProps}
               container
-              spacing={muiGridProps.spacing || 2}
+              spacing={muiGridProps.spacing ?? 2}
             >
               {children}
             </Grid>

--- a/src/components/SQFormDialog/SQFormDialogInner.js
+++ b/src/components/SQFormDialog/SQFormDialogInner.js
@@ -81,7 +81,7 @@ function SQFormDialogInner({
             <Grid
               {...muiGridProps}
               container
-              spacing={muiGridProps.spacing || 2}
+              spacing={muiGridProps.spacing ?? 2}
             >
               {children}
             </Grid>

--- a/src/components/SQFormDialogStepper/SQFormDialogStepper.js
+++ b/src/components/SQFormDialogStepper/SQFormDialogStepper.js
@@ -221,7 +221,7 @@ export function SQFormDialogStepper({
               <Grid
                 {...muiGridProps}
                 container
-                spacing={muiGridProps.spacing || 3}
+                spacing={muiGridProps.spacing ?? 3}
                 justify="center"
               >
                 {currentChild}


### PR DESCRIPTION
Use nullish coalescing operator (??) instead of or (||) operator to
check for existence of `spacing` value which can be 0 which is falsy
causing unexpected values.

✅ Closes: 114