### PR TITLE
fix: 🐛 run date validation on date picker window close

### DIFF
--- a/src/components/SQForm/SQFormDatePicker.js
+++ b/src/components/SQForm/SQFormDatePicker.js
@@ -58,6 +58,9 @@ function SQFormDatePicker({
         shouldDisableDate={setDisabledDate}
         value={value}
         onChange={handleChange}
+        onClose={() => {
+          helpers.setTouched();
+        }}
         renderInput={inputProps => {
           return (
             <TextField

--- a/stories/SQFormDatePicker.stories.js
+++ b/stories/SQFormDatePicker.stories.js
@@ -46,3 +46,26 @@ export const basicDatePicker = () => {
     </SQForm>
   );
 };
+
+const schemaBefore2024 = {
+  date: Yup.date()
+    .required()
+    .max(new Date('2024-01-01'), 'Date must be before 2024')
+    .typeError('Invalid date')
+};
+
+export const datePickerBefore2024 = () => {
+  return (
+    <SQForm
+      initialValues={MOCK_INITIAL_STATE}
+      onSubmit={handleSubmit}
+      validationSchema={schemaBefore2024}
+    >
+      <SQFormDatePicker
+        name="date"
+        label="Date"
+        isDisabled={boolean('isDisabled')}
+      />
+    </SQForm>
+  );
+};


### PR DESCRIPTION
Date validation was only running on blur of the text element, meaning if
you only used the window, it didn't validate until you focused and
blured the text input or tried to submit. Used setTouched to remedy
this.

✅ Closes: #127

before: https://www.loom.com/share/b8946d66630342f396d11444bac681d9
after: https://www.loom.com/share/e4c1ecd7f8994d25ba53ba5e1518ae8b

There are still some issues here with both the datetimepicker and calendaronlydatepicker components. This did not fix them, I think their issues might be more related to some yup and moment clash but didn't have time to ferret those out in this ticket. I'll try to make an issue demoing both of those issues tomorrow.