### PR TITLE
fix: 🐛 setFieldValue now updates inputValue on SQFormAutocomple

### DIFF
--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -115,6 +115,10 @@ function SQFormAutocomplete({
   const prevValue = usePrevious(value);
 
   React.useEffect(() => {
+    setInputValue(initialValue?.label || '');
+  }, [initialValue]);
+
+  React.useEffect(() => {
     // Form Reset
     if (prevValue && inputValue && !value) {
       setInputValue('');


### PR DESCRIPTION
setFieldValue was only updating the initialValue of SQFormAutocomplete
so the visible TextField would not reflect the change. Now that we also set the inputValue, the set option will display.

Loom showing fixed example: https://www.loom.com/share/59e0d88fe6aa470cb01ddf8f9261a5e1

✅ Closes: #144