### PR TITLE
fix: 🐛 Autocomplete no longer uncontrolled with '' initialValue

### DIFF
--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -14,6 +14,8 @@ import {useForm} from './useForm';
 // MUI uses px, a numeric value is needed for calculations
 const LISTBOX_PADDING = 8; // px
 
+const EMPTY_OPTION = {label: '', value: ''};
+
 const useStyles = makeStyles({
   listbox: {
     '& ul': {
@@ -162,12 +164,12 @@ function SQFormAutocomplete({
         disableListWrap
         classes={classes}
         ListboxComponent={ListboxVirtualizedComponent}
-        options={children}
+        options={[...children, EMPTY_OPTION]}
         onBlur={handleAutocompleteBlur}
         onChange={handleAutocompleteChange}
         onInputChange={handleInputChange}
         inputValue={inputValue}
-        value={initialValue}
+        value={initialValue || EMPTY_OPTION}
         disableClearable={isDisabled}
         freeSolo={isDisabled}
         getOptionLabel={option => option.label}


### PR DESCRIPTION
SQFormAutocomplete used to be uncontrolled if you supplied an empty
string iitialValue. This is not something we would expect. These changes
fix that.

✅ Closes: #132

Loom: https://www.loom.com/share/2ac13968b25241cda1542f7cd29ca79b