### PR TITLE
fix: 🐛 change components to use `FormControl` for state props

### DIFF
--- a/src/components/SQForm/SQFormCheckboxGroup.js
+++ b/src/components/SQForm/SQFormCheckboxGroup.js
@@ -81,16 +81,20 @@ function SQFormCheckboxGroup({
 
   return (
     <Grid item sm={size}>
-      <FormControl component="fieldset">
-        <FormLabel component="legend" classes={{root: 'MuiInputLabel-root'}}>
+      <FormControl component="fieldset" required={isRequired}>
+        <FormLabel
+          component="legend"
+          classes={{
+            root: 'MuiInputLabel-root',
+            asterisk: 'MuiInputLabel-asterisk'
+          }}
+        >
           {groupLabel}
         </FormLabel>
         <FormGroup row={shouldDisplayInRow}>
           {childrenToCheckboxGroupItems()}
         </FormGroup>
-        <FormHelperText required={isRequired}>
-          {HelperTextComponent}
-        </FormHelperText>
+        <FormHelperText>{HelperTextComponent}</FormHelperText>
       </FormControl>
     </Grid>
   );

--- a/src/components/SQForm/SQFormDropdown.js
+++ b/src/components/SQForm/SQFormDropdown.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import Input from '@material-ui/core/Input';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -83,38 +84,39 @@ function SQFormDropdown({
 
   return (
     <Grid item sm={size}>
-      <InputLabel error={isFieldError} id={labelID}>
-        {label}
-      </InputLabel>
-      <Select
-        displayEmpty={true}
-        input={<Input disabled={isDisabled} name={name} />}
-        value={field.value}
-        onBlur={handleBlur}
-        onChange={handleChange}
-        fullWidth={true}
-        labelId={labelID}
-        renderValue={renderValue}
+      <FormControl
         error={isFieldError}
-        {...muiFieldProps}
+        required={isRequired}
+        disabled={isDisabled}
+        fullWidth={true}
       >
-        {options.map(option => {
-          return (
-            <MenuItem
-              key={option.value}
-              disabled={option.isDisabled}
-              value={option.value}
-            >
-              {option.label}
-            </MenuItem>
-          );
-        })}
-      </Select>
-      {!isDisabled && (
-        <FormHelperText error={isFieldError} required={isRequired}>
-          {HelperTextComponent}
-        </FormHelperText>
-      )}
+        <InputLabel shrink={true} id={labelID}>
+          {label}
+        </InputLabel>
+        <Select
+          displayEmpty={true}
+          input={<Input name={name} />}
+          value={field.value}
+          onBlur={handleBlur}
+          onChange={handleChange}
+          labelId={labelID}
+          renderValue={renderValue}
+          {...muiFieldProps}
+        >
+          {options.map(option => {
+            return (
+              <MenuItem
+                key={option.value}
+                disabled={option.isDisabled}
+                value={option.value}
+              >
+                {option.label}
+              </MenuItem>
+            );
+          })}
+        </Select>
+        {!isDisabled && <FormHelperText>{HelperTextComponent}</FormHelperText>}
+      </FormControl>
     </Grid>
   );
 }

--- a/src/components/SQForm/SQFormMultiSelect.js
+++ b/src/components/SQForm/SQFormMultiSelect.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import Input from '@material-ui/core/Input';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -148,58 +149,65 @@ function SQFormMultiSelect({
 
   return (
     <Grid item sm={size}>
-      <InputLabel id={labelID}>{label}</InputLabel>
-      <Tooltip
-        placement={toolTipPlacement}
-        arrow
-        enterDelay={1000}
-        leaveDelay={100}
-        title={toolTipEnabled ? toolTipTitle : ''}
+      <FormControl
+        error={isFieldError}
+        disabled={isDisabled}
+        required={isRequired}
+        fullWidth={true}
       >
-        <Select
-          multiple
-          displayEmpty
-          input={<Input disabled={isDisabled} name={name} />}
-          value={field.value || []}
-          onBlur={handleBlur}
-          onChange={handleMultiSelectChange}
-          fullWidth={true}
-          labelId={labelID}
-          renderValue={getRenderValue}
-          MenuProps={MenuProps}
-          onOpen={toggleTooltip}
-          onClose={toggleTooltip}
-          {...muiFieldProps}
+        <InputLabel shrink={true} id={labelID}>
+          {label}
+        </InputLabel>
+        <Tooltip
+          placement={toolTipPlacement}
+          arrow
+          enterDelay={1000}
+          leaveDelay={100}
+          title={toolTipEnabled ? toolTipTitle : ''}
         >
-          {useSelectAll && (
-            <MenuItem
-              value={children?.length === field.value?.length ? 'NONE' : 'ALL'}
-            >
-              <Checkbox checked={children?.length === field.value?.length} />
-              <ListItemText
-                primary="Select All"
-                primaryTypographyProps={{variant: 'body2'}}
-              />
-            </MenuItem>
-          )}
-          {children?.map(option => {
-            return (
-              <MenuItem key={option.value} value={option.value}>
-                <Checkbox checked={field.value?.includes(option.value)} />
+          <Select
+            multiple
+            displayEmpty
+            input={<Input disabled={isDisabled} name={name} />}
+            value={field.value || []}
+            onBlur={handleBlur}
+            onChange={handleMultiSelectChange}
+            fullWidth={true}
+            labelId={labelID}
+            renderValue={getRenderValue}
+            MenuProps={MenuProps}
+            onOpen={toggleTooltip}
+            onClose={toggleTooltip}
+            {...muiFieldProps}
+          >
+            {useSelectAll && (
+              <MenuItem
+                value={
+                  children?.length === field.value?.length ? 'NONE' : 'ALL'
+                }
+              >
+                <Checkbox checked={children?.length === field.value?.length} />
                 <ListItemText
-                  primary={option.label}
+                  primary="Select All"
                   primaryTypographyProps={{variant: 'body2'}}
                 />
               </MenuItem>
-            );
-          })}
-        </Select>
-      </Tooltip>
-      {!isDisabled && (
-        <FormHelperText error={isFieldError} required={isRequired}>
-          {HelperTextComponent}
-        </FormHelperText>
-      )}
+            )}
+            {children?.map(option => {
+              return (
+                <MenuItem key={option.value} value={option.value}>
+                  <Checkbox checked={field.value?.includes(option.value)} />
+                  <ListItemText
+                    primary={option.label}
+                    primaryTypographyProps={{variant: 'body2'}}
+                  />
+                </MenuItem>
+              );
+            })}
+          </Select>
+        </Tooltip>
+        {!isDisabled && <FormHelperText>{HelperTextComponent}</FormHelperText>}
+      </FormControl>
     </Grid>
   );
 }

--- a/src/components/SQForm/SQFormRadioButtonGroup.js
+++ b/src/components/SQForm/SQFormRadioButtonGroup.js
@@ -44,8 +44,14 @@ function SQFormRadioButtonGroup({
 
   return (
     <Grid item sm={size}>
-      <FormControl component="fieldset">
-        <FormLabel component="legend" classes={{root: 'MuiInputLabel-root'}}>
+      <FormControl component="fieldset" required={isRequired}>
+        <FormLabel
+          component="legend"
+          classes={{
+            root: 'MuiInputLabel-root',
+            asterisk: 'MuiInputLabel-asterisk'
+          }}
+        >
           {groupLabel}
         </FormLabel>
         <RadioGroup
@@ -57,9 +63,7 @@ function SQFormRadioButtonGroup({
         >
           {childrenToRadioGroupItems()}
         </RadioGroup>
-        <FormHelperText required={isRequired}>
-          {HelperTextComponent}
-        </FormHelperText>
+        <FormHelperText>{HelperTextComponent}</FormHelperText>
       </FormControl>
     </Grid>
   );


### PR DESCRIPTION
Inputs, labels, and helper text will get error, disabled, and required
state from `FormControl`. Reduces duplication, functionality remains the
same

https://www.loom.com/share/bf0424fdf5e5423fa65d9234f73c3b1d

✅ Closes: #160