### PR TITLE
fix: 🐛 correct error state when initial values provided

### DIFF
--- a/src/components/SQForm/SQFormDatePicker.js
+++ b/src/components/SQForm/SQFormDatePicker.js
@@ -58,9 +58,6 @@ function SQFormDatePicker({
         shouldDisableDate={setDisabledDate}
         value={value}
         onChange={handleChange}
-        onClose={() => {
-          helpers.setTouched();
-        }}
         renderInput={inputProps => {
           return (
             <TextField

--- a/src/components/SQForm/useForm.js
+++ b/src/components/SQForm/useForm.js
@@ -44,7 +44,7 @@ export function useForm({name, isRequired, onBlur, onChange}) {
   const isTouched = getIn(meta, 'touched');
   const hasValue = _getHasValue(meta);
   const isError = !!errorMessage;
-  const isFieldError = isTouched && isError;
+  const isFieldError = (isTouched || hasValue) && isError;
   const isFieldRequired = isRequired && !hasValue;
   const isFulfilled = _getIsFulfilled(hasValue, isError);
 


### PR DESCRIPTION
Validation errors aren't showing on mount because `isFieldError` uses
`isTouched`. The field won't be considered touched until the user clicks
it, which is why we're seeing the current behavior. If we use `hasValue`
it will show those errors when the field has an initial value.

https://www.loom.com/share/2049ee6738ee477dabb9df1bce9d5596

Also fixes #89: https://www.loom.com/share/1b49b2a0125d4fd8b082097b31c950c0

✅ Closes: #165, #89, #147