### PR TITLE
feat: 🎸 SQFormAutocomplete options are now disableable

### DIFF
--- a/src/components/SQForm/SQFormAsyncAutocomplete.js
+++ b/src/components/SQForm/SQFormAsyncAutocomplete.js
@@ -166,6 +166,7 @@ function SQFormAsyncAutocomplete({
         onClose={onClose}
         inputValue={inputValue}
         getOptionLabel={option => option.label}
+        getOptionDisabled={option => option.isDisabled}
         renderInput={params => {
           return (
             <TextField

--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -173,6 +173,7 @@ function SQFormAutocomplete({
         disableClearable={isDisabled}
         freeSolo={isDisabled}
         getOptionLabel={option => option.label}
+        getOptionDisabled={option => option.isDisabled}
         renderInput={params => {
           return (
             <TextField

--- a/stories/SQForm.stories.js
+++ b/stories/SQForm.stories.js
@@ -43,7 +43,11 @@ export default {
 const MOCK_AUTOCOMPLETE_OPTIONS = Array.from(new Array(10000))
   .map(() => {
     const randomValue = random(10 + Math.ceil(Math.random() * 20));
-    return {label: randomValue, value: randomValue};
+    return {
+      label: randomValue,
+      value: randomValue,
+      isDisabled: Math.random() > 0.8
+    };
   })
   .sort((a, b) => a.label.toUpperCase().localeCompare(b.label.toUpperCase()));
 


### PR DESCRIPTION
SQFormAutocomplete and SQFormAsyncAutocomplete options are now
disableable in the same way that SQFormDropdown options are

✅ Closes: #172

Loom: https://www.loom.com/share/d2856fc315604254ba4573c6d16412d9