### PR TITLE
ci: 🎡 Disables semantic-release Release comments on PR/issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
           "docs",
           "chore",
           "refactor",
-          "test"
+          "test",
+          "ci"
         ]
       ]
     }

--- a/release.config.js
+++ b/release.config.js
@@ -18,7 +18,12 @@ module.exports = {
       }
     ],
     '@semantic-release/npm',
-    '@semantic-release/github',
+    [
+      '@semantic-release/github',
+      {
+        successComment: false
+      }
+    ],
     [
       '@semantic-release/git',
       {


### PR DESCRIPTION
✅ Closes: #183

This should disable the Semantic-Release bot comments that occur on a PR when a deployment occurs. It's neat to have that comment for historical purposes. However, it's very noisy in our frontend-libraries channel and we can obtain the same information in our Changelog. 

Since I can't really prove CI work in a loom video, here's a link to the documentation for this change. https://github.com/semantic-release/github#options