### PR TITLE
Issue 185 close datepicker with calendar input only modal

### DIFF
--- a/src/components/SQForm/SQFormDatePicker.js
+++ b/src/components/SQForm/SQFormDatePicker.js
@@ -27,7 +27,9 @@ function SQFormDatePicker({
   onChange,
   setDisabledDate,
   muiFieldProps = {},
-  muiTextInputProps = {}
+  muiTextInputProps = {},
+  isOpen,
+  closeCalendar
 }) {
   const {
     formikField: {field, helpers},
@@ -51,6 +53,9 @@ function SQFormDatePicker({
   const handleClickAway = () => {
     if (isCalendarOpen) {
       setIsCalendarOpen(false);
+    }
+    if (isOpen) {
+      closeCalendar();
     }
   };
 
@@ -123,7 +128,11 @@ SQFormDatePicker.propTypes = {
   /** Any valid prop for material ui datepicker child component - https://material-ui.com/components/pickers/  */
   muiFieldProps: PropTypes.object,
   /** Any valid prop for MUI input field - https://material-ui.com/api/text-field/ & https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attributes */
-  muiTextInputProps: PropTypes.object
+  muiTextInputProps: PropTypes.object,
+  /** Calendar isOpen flag which indicates that either dialog is opened or closed*/
+  isOpen: PropTypes.bool,
+  /** Calendar closing function which close the calendar dialog */
+  closeCalendar: PropTypes.func
 };
 
 export default SQFormDatePicker;

--- a/src/components/SQForm/SQFormDatePickerWithCalendarInputOnly.js
+++ b/src/components/SQForm/SQFormDatePickerWithCalendarInputOnly.js
@@ -62,6 +62,8 @@ function SQFormDatePickerWithCalendarInputOnly({
       onBlur={onBlur}
       onChange={onChange}
       setDisabledDate={setDisabledDate}
+      isOpen={isOpen}
+      closeCalendar={closeCalendar}
       muiFieldProps={{
         ...muiFieldProps,
         open: isOpen,


### PR DESCRIPTION
fix: 🐛 close the datepicker modal  when we click outside

close the datepicker modal when we click outside the datepicker modal

✅ Closes: 185


https://www.loom.com/share/073f042148ed43f3a3fc6dc27b7b3848

screenshot of story:
![image](https://user-images.githubusercontent.com/76514364/113690714-20fc1280-96e5-11eb-943a-1f724e7824ad.png)
