### PR TITLE
docs: ✏️ stories for TextField, Textarea, and ReadOnlyField

### DIFF
--- a/stories/SQFormReadOnlyField.stories.js
+++ b/stories/SQFormReadOnlyField.stories.js
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import {SQFormReadOnlyField as SQFormReadOnlyFieldComponent} from '../src';
+import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
+import {createDocsPage} from './utils/createDocsPage';
+import markdown from '../notes/SQFormReadOnlyField.md';
+
+export default {
+  title: 'Components/SQFormReadOnlyField',
+  component: SQFormReadOnlyFieldComponent,
+  argTypes: {
+    name: {table: {disable: true}}
+  },
+  parameters: {
+    docs: {
+      page: createDocsPage({markdown})
+    }
+  }
+};
+
+const defaultArgs = {
+  label: 'ReadOnly Field',
+  name: 'readOnlyField'
+};
+
+const Template = ({initialValue = '', ...args}) => {
+  return (
+    <SQFormStoryWrapper initialValues={{[defaultArgs.name]: initialValue}}>
+      <SQFormReadOnlyFieldComponent
+        {...args}
+        size={args.size !== 'auto' ? Number(args.size) : args.size}
+      />
+    </SQFormStoryWrapper>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = defaultArgs;
+
+export const WithInitialValue = Template.bind({});
+WithInitialValue.args = {
+  ...defaultArgs,
+  initialValue: 'Hello world!'
+};
+WithInitialValue.parameters = {
+  controls: {exclude: 'initialValue'}
+};

--- a/stories/SQFormTextField.stories.js
+++ b/stories/SQFormTextField.stories.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import * as Yup from 'yup';
+
+import {SQFormTextField as SQFormTextFieldComponent} from '../src';
+import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
+import {createDocsPage} from './utils/createDocsPage';
+
+export default {
+  title: 'Components/SQFormTextField',
+  component: SQFormTextFieldComponent,
+  argTypes: {
+    onBlur: {action: 'blurred', table: {disable: true}},
+    onChange: {action: 'changed', table: {disable: true}},
+    name: {table: {disable: true}}
+  },
+  parameters: {
+    docs: {
+      page: createDocsPage()
+    }
+  }
+};
+
+const defaultArgs = {
+  label: 'Text Field',
+  name: 'textField'
+};
+
+const Template = args => {
+  const {schema, ...rest} = args;
+  return (
+    <SQFormStoryWrapper
+      initialValues={{[defaultArgs.name]: ''}}
+      validationSchema={schema}
+    >
+      <SQFormTextFieldComponent
+        {...rest}
+        size={args.size !== 'auto' ? Number(args.size) : args.size}
+      />
+    </SQFormStoryWrapper>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = defaultArgs;
+
+export const WithValidation = Template.bind({});
+WithValidation.args = {
+  ...defaultArgs,
+  isRequired: true,
+  schema: {
+    [defaultArgs.name]: Yup.string().required('Required')
+  }
+};
+WithValidation.parameters = {
+  controls: {exclude: 'schema'}
+};

--- a/stories/SQFormTextarea.stories.js
+++ b/stories/SQFormTextarea.stories.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import * as Yup from 'yup';
+
+import {SQFormTextarea as SQFormTextareaComponent} from '../src';
+import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
+import {createDocsPage} from './utils/createDocsPage';
+
+export default {
+  title: 'Components/SQFormTextarea',
+  component: SQFormTextareaComponent,
+  argTypes: {
+    onBlur: {action: 'blurred', table: {disable: true}},
+    onChange: {action: 'changed', table: {disable: true}},
+    name: {table: {disable: true}}
+  },
+  parameters: {
+    docs: {
+      page: createDocsPage()
+    }
+  }
+};
+
+const defaultArgs = {
+  label: 'Textarea',
+  name: 'textarea'
+};
+
+const Template = args => {
+  const {schema, ...rest} = args;
+  return (
+    <SQFormStoryWrapper
+      initialValues={{[defaultArgs.name]: ''}}
+      validationSchema={schema}
+    >
+      <SQFormTextareaComponent
+        {...rest}
+        size={args.size !== 'auto' ? Number(args.size) : args.size}
+      />
+    </SQFormStoryWrapper>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = defaultArgs;
+
+export const WithValidation = Template.bind({});
+WithValidation.args = {
+  ...defaultArgs,
+  isRequired: true,
+  schema: {
+    [defaultArgs.name]: Yup.string().required('Required')
+  }
+};
+WithValidation.parameters = {
+  controls: {exclude: 'schema'}
+};

--- a/stories/components/SQFormStoryWrapper.js
+++ b/stories/components/SQFormStoryWrapper.js
@@ -19,7 +19,7 @@ export const SQFormStoryWrapper = ({
     <SQForm
       initialValues={initialValues}
       validationSchema={validationSchema}
-      muiGridProps={muiGridProps}
+      muiGridProps={{wrap: 'nowrap', ...muiGridProps}}
       onSubmit={withFormikActions('submitted')}
     >
       {children}


### PR DESCRIPTION
Stories with auto-generated controls and docs. 

You may have noticed that I've been disabling the `name` prop in the controls tab - this is to prevent errors that would be caused by deleting the content of that field (because it's a required prop and we don't have a fallback for when it's empty). Also, if you change the name then submit, the submitted value shows the initial name _and_ the new name, which doesn't represent how the component actually works.
This only affects the prop rendering in Controls, it still shows in the props table in the Docs tab.

https://www.loom.com/share/bc1b17ed9f3e4dfd8175623a96a3e101

✅ Closes: #194