### PR TITLE
chore: 🤖 ignore `@storybook/addon-docs` in jest config

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,5 +1,5 @@
 {
-  "presets": [["@babel/preset-env"],["@babel/preset-react"]],
+  "presets": [["@babel/preset-env"], ["@babel/preset-react"]],
   "plugins": [
     "react-docgen",
     "@babel/plugin-proposal-nullish-coalescing-operator",

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,5 +7,6 @@ module.exports = {
   },
   moduleNameMapper: {
     '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.js'
-  }
+  },
+  transformIgnorePatterns: ['/node_modules/(?!@storybook/addon-docs).+\\.js$']
 };


### PR DESCRIPTION
The tests using stories were failing because
`@storybook/addon-docs/blocks` is using esm, which jest currently does
not understand. I've added that package to the `transformIgnorePatterns`
list in the jest config to solve that, but also had to change the
`.babelrc` to `babel.config.json` due to updates in Babel v7

Apparently, the deal with Babel 7 is that it no longer automatically loads the `.babelrc`. It now has the concept of a `root` directory, which is the current working directory by default, where it looks for a `babel.config.json` file. With this change Jest will be able to properly load the babel config.

References: 
- [similar situation with a different storybook package using esm](https://github.com/storybookjs/storybook/issues/9470#issuecomment-574790318)
- [Babel 7 config files docs](https://babeljs.io/docs/en/config-files#project-wide-configuration)
- [Jest issue demonstrating `.babelrc` vs `babel.config.js` when using `transformIgnorePatterns`](https://github.com/facebook/jest/issues/10256)

✅ Closes: #204