### PR TITLE
fix: 🐛 dropdown arrow visible when autocomplete disabled

### DIFF
--- a/src/components/SQForm/SQFormAsyncAutocomplete.js
+++ b/src/components/SQForm/SQFormAsyncAutocomplete.js
@@ -165,6 +165,7 @@ function SQFormAsyncAutocomplete({
         onOpen={onOpen}
         onClose={onClose}
         inputValue={inputValue}
+        disabled={isDisabled}
         getOptionLabel={option => option.label}
         getOptionDisabled={option => option.isDisabled}
         renderInput={params => {

--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -185,7 +185,7 @@ function SQFormAutocomplete({
         inputValue={inputValue}
         value={initialValue || null}
         disableClearable={isDisabled}
-        freeSolo={isDisabled}
+        disabled={isDisabled}
         getOptionLabel={option => option.label || ''}
         getOptionDisabled={option => option.isDisabled}
         renderInput={params => {


### PR DESCRIPTION
When the autocomplete was disabled it also hid the dropdown arrow - this
was caused by `freeSolo={isDisabled}` (added in #136) on the Mui Autocomplete. I
switched that to `disabled={isDisabled`, so now when the component is
disabled the arrow is still visible, but not clickable. This more
closely resembles the disabled behavior of SQFormDropdown.
Also added the same prop to `SQFormAsyncAutocomplete`

https://www.loom.com/share/38c7e8f8a5384021ab438ab22921f471

✅ Closes: #213