### PR TITLE
docs: ✏️ add story testing package, refactor dropdown story

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9007,6 +9007,17 @@
         }
       }
     },
+    "@storybook/testing-react": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/testing-react/-/testing-react-0.0.10.tgz",
+      "integrity": "sha512-8R5ca411vY2JpnxYvcbvAX8WjcfFsi6u98JPweUsIBV2lAQlm3GZxL7AlhIILEhp/CdYQervEMmzVGcN0kYvvQ==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "^6.1.21",
+        "@storybook/client-api": "^6.1.21",
+        "@storybook/react": "^6.1.21"
+      }
+    },
     "@storybook/theming": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@storybook/addons": "^6.2.3",
     "@storybook/preset-create-react-app": "^3.1.7",
     "@storybook/react": "^6.2.3",
+    "@storybook/testing-react": "0.0.10",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^13.0.7",

--- a/stories/SQFormDropdown.stories.js
+++ b/stories/SQFormDropdown.stories.js
@@ -12,7 +12,8 @@ export default {
     children: {table: {disable: true}},
     onBlur: {action: 'blurred', table: {disable: true}},
     onChange: {action: 'changed', table: {disable: true}},
-    name: {table: {disable: true}}
+    name: {table: {disable: true}},
+    SQFormProps: {table: {disable: true}}
   },
   parameters: {
     docs: {
@@ -32,22 +33,25 @@ const MOCK_STATE_OPTIONS = [
 
 const defaultArgs = {
   label: 'State',
-  name: 'state'
+  name: 'state',
+  children: MOCK_STATE_OPTIONS,
+  SQFormProps: {
+    initialValues: {state: ''}
+  }
 };
 
-export const SQFormDropdown = args => (
-  <div style={{minWidth: 250}}>
-    <SQFormStoryWrapper initialValues={{[defaultArgs.name]: ''}}>
-      <SQFormDropdownComponent
-        label={defaultArgs.label}
-        name={defaultArgs.name}
-        {...args}
-        size={args.size !== 'auto' ? Number(args.size) : args.size}
-      >
-        {MOCK_STATE_OPTIONS}
-      </SQFormDropdownComponent>
-    </SQFormStoryWrapper>
-  </div>
-);
+export const SQFormDropdown = args => {
+  const {SQFormProps, ...dropdownProps} = args;
+  return (
+    <div style={{minWidth: 250}}>
+      <SQFormStoryWrapper {...defaultArgs.SQFormProps} {...SQFormProps}>
+        <SQFormDropdownComponent
+          {...dropdownProps}
+          size={args.size !== 'auto' ? Number(args.size) : args.size}
+        />
+      </SQFormStoryWrapper>
+    </div>
+  );
+};
 SQFormDropdown.storyName = 'SQFormDropdown';
 SQFormDropdown.args = defaultArgs;


### PR DESCRIPTION
Refactored the dropdown story to handle passing props to the SQForm
wrapper when testing. Also, the `@storybook/testing-react` package will
be needed to properly compose the args on the component when testing.

In this loom I copied these changes over to @laurelbean's PR #180 to demo how it works
https://www.loom.com/share/5540a09c66e440e0be7aa5bca62aa2df