### PR TITLE
issue-212: Fix misaligned select field

### DIFF
--- a/src/components/SQForm/SQFormDropdown.js
+++ b/src/components/SQForm/SQFormDropdown.js
@@ -7,6 +7,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import InputLabel from '@material-ui/core/InputLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Grid from '@material-ui/core/Grid';
+import {makeStyles} from '@material-ui/core/styles';
 
 import {useForm} from './useForm';
 import {
@@ -18,6 +19,14 @@ import {EMPTY_LABEL} from '../../utils/constants';
 
 const EMPTY_VALUE = '';
 const EMPTY_OPTION = {label: EMPTY_LABEL, value: EMPTY_VALUE};
+
+const useStyles = makeStyles({
+  selectHeight: {
+    '& .MuiSelect-selectMenu': {
+      height: '1.1876em'
+    }
+  }
+});
 
 function SQFormDropdown({
   children,
@@ -31,6 +40,8 @@ function SQFormDropdown({
   size = 'auto',
   muiFieldProps = {}
 }) {
+  const classes = useStyles();
+
   const {
     formikField: {field},
     fieldState: {isFieldError},
@@ -94,6 +105,7 @@ function SQFormDropdown({
           {label}
         </InputLabel>
         <Select
+          className={classes.selectHeight}
           displayEmpty={true}
           input={<Input name={name} />}
           value={field.value}

--- a/src/components/SQForm/SQFormMultiSelect.js
+++ b/src/components/SQForm/SQFormMultiSelect.js
@@ -10,6 +10,7 @@ import Grid from '@material-ui/core/Grid';
 import Checkbox from '@material-ui/core/Checkbox';
 import ListItemText from '@material-ui/core/ListItemText';
 import Tooltip from '@material-ui/core/Tooltip';
+import {makeStyles} from '@material-ui/core/styles';
 import {useSQFormContext} from '../../../src';
 import {EMPTY_LABEL} from '../../utils/constants';
 import {useForm} from './useForm';
@@ -60,6 +61,14 @@ const getToolTipTitle = (formikFieldValue, options) => {
   return selectedDisplayValue(formikFieldValue, options);
 };
 
+const useStyles = makeStyles({
+  selectHeight: {
+    '& .MuiSelect-selectMenu': {
+      height: '1.1876em'
+    }
+  }
+});
+
 function SQFormMultiSelect({
   children,
   isDisabled = false,
@@ -72,6 +81,8 @@ function SQFormMultiSelect({
   toolTipPlacement = 'bottom',
   muiFieldProps = {}
 }) {
+  const classes = useStyles();
+
   const {setFieldValue} = useSQFormContext();
   const [toolTipEnabled, setToolTipEnabled] = React.useState(true);
   const {
@@ -166,6 +177,7 @@ function SQFormMultiSelect({
           title={toolTipEnabled ? toolTipTitle : ''}
         >
           <Select
+            className={classes.selectHeight}
             multiple
             displayEmpty
             input={<Input disabled={isDisabled} name={name} />}


### PR DESCRIPTION
Fixed the components that misaligned bottom borders due to the MUI Select. SQFormDropdown and SQFormMultiselect.

Before: 
![image](https://user-images.githubusercontent.com/29528409/116267537-1f50c800-a742-11eb-9281-235634924ce5.png)

After:
<img width="432" alt="Screen Shot 2021-04-27 at 10 17 23 AM" src="https://user-images.githubusercontent.com/29528409/116267573-2546a900-a742-11eb-9675-2063a8a01d2f.png">
