### PR TITLE
fix: 🐛 SQFormCheckboxGroup properly accepts non string values

### DIFF
--- a/src/components/SQForm/SQFormCheckboxGroupItem.js
+++ b/src/components/SQForm/SQFormCheckboxGroupItem.js
@@ -33,7 +33,7 @@ function SQFormCheckboxGroupItem({
 
   const isChecked = React.useMemo(() => {
     if (Array.isArray(field.value)) {
-      return field.value.includes(value);
+      return field.value.includes(value.toString());
     }
 
     return field.value;

--- a/stories/SQForm.stories.js
+++ b/stories/SQForm.stories.js
@@ -137,10 +137,10 @@ const RADIO_GROUP_OPTIONS = [
 ];
 
 const CHECKBOX_GROUP_OPTIONS = [
-  {label: 'Glass', value: 'glass'},
-  {label: 'Drivetrain', value: 'drivetrain'},
-  {label: 'Brakes', value: 'brakes'},
-  {label: 'Interior', value: 'interior', isDisabled: true}
+  {label: 'Glass', value: 1},
+  {label: 'Drivetrain', value: 2},
+  {label: 'Brakes', value: 3},
+  {label: 'Interior', value: 4, isDisabled: true}
 ];
 
 const handleSubmit = (values, actions) => {


### PR DESCRIPTION
SQFormCheckboxGroup's MUI Checkbox casts the value to a string and as a
result the isChecked comparison fails if a non-string value was passed.
A simple cast in our own code fixes this issue.

✅ Closes: #231