### PR TITLE
fix: 🐛 SQFormCheckboxGroup select all is a normal checkbox

### DIFF
--- a/src/components/SQForm/SQFormCheckboxGroup.js
+++ b/src/components/SQForm/SQFormCheckboxGroup.js
@@ -7,6 +7,7 @@ import Grid from '@material-ui/core/Grid';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import FormGroup from '@material-ui/core/FormGroup';
 import SQFormCheckboxGroupItem from './SQFormCheckboxGroupItem';
+import SQFormCheckbox from './SQFormCheckbox';
 import {useForm} from './useForm';
 
 function SQFormCheckboxGroup({
@@ -39,12 +40,11 @@ function SQFormCheckboxGroup({
     const enabledGroupValues = children.reduce((acc, checkboxOption) => {
       const {value, isDisabled} = checkboxOption;
       if (!isDisabled) {
-        return [...acc, value];
+        return [...acc, value.toString()];
       }
 
       return acc;
     }, []);
-
     setFieldValue(name, enabledGroupValues);
   };
 
@@ -67,11 +67,9 @@ function SQFormCheckboxGroup({
     });
     if (shouldUseSelectAll) {
       return [
-        <SQFormCheckboxGroupItem
-          groupName="selectAll"
+        <SQFormCheckbox
+          name={`${name}SelectAll`}
           label="All"
-          value="selectAll"
-          isRowDisplay={shouldDisplayInRow}
           onChange={handleSelectAllChange}
         />,
         ...providedCheckboxItems

--- a/stories/SQForm.stories.js
+++ b/stories/SQForm.stories.js
@@ -65,7 +65,8 @@ const MOCK_FORM_ENTITY = {
   tenThousandOptions: '',
   note: '',
   preferredPet: '',
-  warrantyOptions: []
+  warrantyOptions: [],
+  warrantyOptionsSelectAll: false
 };
 
 const MOCK_ACTIONS_FORM_ENTITY = {
@@ -192,6 +193,7 @@ export const BasicForm = () => {
           name="warrantyOptions"
           groupLabel="Warranty Options"
           shouldDisplayInRow={true}
+          shouldUseSelectAll={true}
         >
           {CHECKBOX_GROUP_OPTIONS}
         </SQFormCheckboxGroup>


### PR DESCRIPTION
SQFormCheckboxGroup's select all checkbox is a normal checkbox and has a
dynamic name allowing for multiple select all checkboxes.

✅ Closes: #234