### PR TITLE
fix: 🐛 add spacing below radio/checkbox items

### DIFF
--- a/src/components/SQForm/SQFormCheckboxGroupItem.js
+++ b/src/components/SQForm/SQFormCheckboxGroupItem.js
@@ -5,11 +5,14 @@ import Checkbox from '@material-ui/core/Checkbox';
 import {makeStyles} from '@material-ui/core/styles';
 import {useForm} from './useForm';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   checkboxGroupItem: {
-    marginRight: 30
+    marginBottom: theme.spacing(1.5)
+  },
+  rowDisplay: {
+    marginRight: theme.spacing(3.75)
   }
-});
+}));
 
 function SQFormCheckboxGroupItem({
   groupName,
@@ -41,7 +44,10 @@ function SQFormCheckboxGroupItem({
 
   return (
     <FormControlLabel
-      className={isRowDisplay ? classes.checkboxGroupItem : ''}
+      className={`
+        ${classes.checkboxGroupItem}
+        ${isRowDisplay ? classes.rowDisplay : ''}
+      `}
       label={label}
       control={
         <Checkbox

--- a/src/components/SQForm/SQFormRadioButtonGroupItem.js
+++ b/src/components/SQForm/SQFormRadioButtonGroupItem.js
@@ -4,11 +4,14 @@ import Radio from '@material-ui/core/Radio';
 import {makeStyles} from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   radioButton: {
-    marginRight: 30
+    marginBottom: theme.spacing(1.5)
+  },
+  rowDisplay: {
+    marginRight: theme.spacing(3.75)
   }
-});
+}));
 
 function SQFormRadioButtonGroupItem({
   value,
@@ -21,7 +24,10 @@ function SQFormRadioButtonGroupItem({
 
   return (
     <FormControlLabel
-      className={isRowDisplay ? classes.radioButton : ''}
+      className={`
+        ${classes.radioButton}
+        ${isRowDisplay ? classes.rowDisplay : ''}
+      `}
       value={value}
       label={label}
       control={<Radio disabled={isDisabled} {...inputProps} />}


### PR DESCRIPTION
There's not enough space between radio/checkbox items when the items
have text that wraps, which makes it harder to read. This PR adds a
small margin-bottom to the items

Before:
![image](https://user-images.githubusercontent.com/35306025/117749834-0cc19e80-b1d8-11eb-9f3d-44aeade598b8.png)

After:
![image](https://user-images.githubusercontent.com/35306025/117749888-206d0500-b1d8-11eb-8c9c-81c707ad935d.png)


✅ Closes: #227