### PR TITLE
fix: 🐛 SQFormCheckboxGroup Select all missing key

### DIFF
--- a/src/components/SQForm/SQFormCheckboxGroup.js
+++ b/src/components/SQForm/SQFormCheckboxGroup.js
@@ -71,6 +71,7 @@ function SQFormCheckboxGroup({
           name={`${name}SelectAll`}
           label="All"
           onChange={handleSelectAllChange}
+          key={`${name}_selectAll`}
         />,
         ...providedCheckboxItems
       ];

--- a/stories/__tests__/SQForm.stories.test.js
+++ b/stories/__tests__/SQForm.stories.test.js
@@ -25,7 +25,7 @@ const mockData = {
   state: 'KS',
   cool: true,
   preferredPet: 'dog',
-  warrantyOptions: ['drivetrain', 'brakes'],
+  warrantyOptions: ['2', '3'],
   note: 'Hello World!'
 };
 
@@ -76,6 +76,7 @@ describe('Tests for BasicForm', () => {
             note: '',
             preferredPet: mockData.preferredPet,
             warrantyOptions: mockData.warrantyOptions,
+            warrantyOptionsSelectAll: false,
             hobby: mockData.hobby,
             cool: mockData.cool,
             lame: false
@@ -114,6 +115,7 @@ describe('Tests for BasicForm', () => {
             note: '',
             preferredPet: '',
             warrantyOptions: [],
+            warrantyOptionsSelectAll: false,
             hobby: '',
             cool: false,
             lame: false
@@ -229,7 +231,8 @@ describe('Tests for FormWithValidation', () => {
             tenThousandOptions: firstOption.textContent,
             note: 'Hello World!',
             preferredPet: 'cat',
-            warrantyOptions: ['drivetrain']
+            warrantyOptions: ['2'],
+            warrantyOptionsSelectAll: false
           },
           null,
           2


### PR DESCRIPTION
The key was missing for SQFormCheckboxGroup's select all checkbox
causing console warnings

✅ Closes: #245