### PR TITLE
fix: 🐛 Upgrade SSC version to receive button style fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30019,8 +30019,8 @@
       }
     },
     "scplus-shared-components": {
-      "version": "https://npm-public.selectquotelabs.com/scplus-shared-components/7.0.4",
-      "integrity": "sha512-5agiRSxzQv82hkFaL47bwDFTqiYmYo+ohK3Iv2xPC61AvDehQyFM5B1e8cl24f+9PeRWCZvVdQDNwxwbgssenA==",
+      "version": "https://npm-public.selectquotelabs.com/scplus-shared-components/7.0.6",
+      "integrity": "sha512-Ki9q6mskSQRkDEU/KmMkhopN9wjbklIXYDODuO7eOJ56yKoLycsoqt44evPHVMiZVqYBbP0zHpK/XCXsn4ShYQ==",
       "requires": {
         "@material-ui/core": "^4.11.0",
         "@material-ui/icons": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react-text-mask": "^5.4.3",
     "react-weekly-schedule": "0.0.0-development",
     "react-window": "^1.8.5",
-    "scplus-shared-components": "https://npm-public.selectquotelabs.com/scplus-shared-components/7.0.4",
+    "scplus-shared-components": "https://npm-public.selectquotelabs.com/scplus-shared-components/7.0.6",
     "text-mask-addons": "^3.8.0",
     "use-debounce": "^6.0.0"
   },


### PR DESCRIPTION
SQFormButton relies on the RoundedButton from the SSC library. I recently fixed a styling bug in the MUI theme exposed by SSC. 
This will allow the SQFormButton to have the correct styles when its variant is `outlined` and `disabled`.