### PR TITLE
fix: 🐛 Ensure users cant open calendar input on disabled picker

### DIFF
--- a/src/components/SQForm/SQFormDatePicker.js
+++ b/src/components/SQForm/SQFormDatePicker.js
@@ -87,7 +87,11 @@ function SQFormDatePicker({
                 placeholder={placeholder}
                 onBlur={handleBlur}
                 required={isRequired}
-                onClick={isCalendarOnly ? toggleCalendar : handleClickAway}
+                onClick={
+                  isCalendarOnly && !isDisabled
+                    ? toggleCalendar
+                    : handleClickAway
+                }
                 classes={classes}
               />
             );


### PR DESCRIPTION
Users could still open calendar input on a disabled calenderonly date
picker, and even change the date. This fixes that.

✅ Closes: #260

Loooooom https://www.loom.com/share/c0aa2c65e908403ab88d7290a7b92f3d