### PR TITLE
fix: 🐛 Correctly reset displayempty autocomplete to '- -'

### DIFF
--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -134,9 +134,9 @@ function SQFormAutocomplete({
   React.useEffect(() => {
     // Form Reset
     if (prevValue && inputValue && !value) {
-      setInputValue('');
+      setInputValue(displayEmpty ? EMPTY_OPTION.label : '');
     }
-  }, [value, inputValue, name, prevValue, values]);
+  }, [value, inputValue, name, prevValue, values, displayEmpty]);
 
   const handleAutocompleteBlur = React.useCallback(
     event => {


### PR DESCRIPTION
When resetting an entire form, all autocompletes would reset to empty
string, even if their default state should be '- -'. This fix handles
both cases correctly.

✅ Closes: #250

LoOoOoOOoOO0oom https://www.loom.com/share/6d4a93ccba264c59a52e4fe39bd93565