### PR TITLE
docs: ✏️ Fix broken logo image in storybook (top left)

### DIFF
--- a/.storybook/selectQuoteTheme.js
+++ b/.storybook/selectQuoteTheme.js
@@ -1,6 +1,7 @@
 import {create} from '@storybook/theming/create';
+import SQLogo from '../src/images/SQ-logo-slogan.png';
 
 export default create({
   base: 'light',
-  brandImage: require('../src/images/SQ-logo-slogan.png')
+  brandImage: SQLogo
 });


### PR DESCRIPTION
Fix broken logo image in storybook (top left)

✅ Closes: #262

The below structure change seems to fix it, not sure why ¯\_(ツ)_/¯
<img width="271" alt="Screen Shot 2021-05-21 at 2 44 04 PM" src="https://user-images.githubusercontent.com/12816579/119190900-8e6cc400-ba43-11eb-84db-78f36c9fcf1d.png">

I did find some still open issues on storybook's github about theming cache issues, see https://github.com/storybookjs/storybook/issues/13200

Adding the following seemed to clear it out and let me see the fixed logo. I didn't want to commit it since I don't really know what it might impact for a logo fix (low value) but something to try if you can't get theme changes to show in your local version.
<img width="493" alt="Screen Shot 2021-05-21 at 2 44 24 PM" src="https://user-images.githubusercontent.com/12816579/119190972-a80e0b80-ba43-11eb-82ad-46eae1a289e6.png">
