### PR TITLE
Issue 268  -- SQFormDialog.stories.test.js

### DIFF
--- a/stories/__tests__/SQFormDialog.stories.test.js
+++ b/stories/__tests__/SQFormDialog.stories.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {composeStories} from '@storybook/testing-react';
 
-import userEvent, {specialChars} from '@testing-library/user-event';
+import userEvent from '@testing-library/user-event';
 import * as stories from '../SQFormDialog.stories';
 
 const {Default, WithValidation, WithAutoFocus} = composeStories(stories);
@@ -34,8 +34,10 @@ describe('Tests for Default', () => {
       />
     );
 
-    const dialogTitle = screen.getByText(dialogTitleValue);
-    expect(dialogTitle.textContent).toEqual(dialogTitleValue);
+    const dialogTitle = await waitFor(() =>
+      screen.findByText(dialogTitleValue)
+    );
+    expect(dialogTitle).toHaveTextContent(dialogTitleValue);
   });
 
   it('should handle form updates and submit said updates on save button click', async () => {
@@ -59,7 +61,7 @@ describe('Tests for Default', () => {
     userEvent.type(textField, mockData.hello);
 
     // https://testing-library.com/docs/ecosystem-user-event/#specialchars
-    userEvent.type(textField, `${specialChars.enter}`);
+    userEvent.type(textField, '{enter}');
 
     await waitFor(() => {
       expect(handleSave).toHaveBeenCalledTimes(1);
@@ -117,8 +119,10 @@ describe('Tests for WithAutoFocus', () => {
     );
 
     const dialogTitleValue = 'With Auto Focus';
-    const dialogTitle = screen.getByText(dialogTitleValue);
-    expect(dialogTitle.textContent).toEqual(dialogTitleValue);
+    const dialogTitle = await waitFor(() =>
+      screen.findByText(dialogTitleValue)
+    );
+    expect(dialogTitle).toHaveTextContent(dialogTitleValue);
 
     const textfield = screen.getByLabelText(/hello/i);
     expect(textfield).toBe(document.activeElement);

--- a/stories/__tests__/SQFormDialog.stories.test.js
+++ b/stories/__tests__/SQFormDialog.stories.test.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+  within
+} from '@testing-library/react';
+import {composeStories} from '@storybook/testing-react';
+
+import userEvent from '@testing-library/user-event';
+import * as stories from '../SQFormDialog.stories';
+
+const {Default} = composeStories(stories);
+
+window.alert = jest.fn();
+const handleClose = jest.fn();
+
+afterEach(() => {
+  window.alert.mockClear();
+  handleClose.mockClear();
+});
+
+const mockData = {
+  hello: 'howdy'
+};
+
+describe('Tests for Default', () => {
+  /**
+   * 1. it renders default when the `isOpen` value changes to true,
+   * 2. the Title is correct,
+   * 3. the cancel button closes the dialog,
+   * 4. and the save button submits form and closes dialog
+   */
+  it('renders Default and calls Save on submit', async () => {
+    render(<Default onClose={handleClose} isOpen={true} />);
+
+    userEvent.type(screen.getByLabelText(/hello/i), mockData.hello);
+    // screen.debug();
+    fireEvent.click(screen.getByRole('button', {name: /cancel/i}));
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    // await waitFor(() =>
+    //   expect(window.alert).toHaveBeenCalledWith(
+    //     JSON.stringify(
+    //       {
+    //         hello: mockData.hello
+    //       },
+    //       null,
+    //       2
+    //     )
+    //   )
+    // );
+  });
+});
+
+// describe('Tests for WithValidation', () => {
+//   /**
+//    * 1. When the form validationSchema is not satisfied, the Save button is disabled
+//    * 2. When the validationSchema IS satisfied, the Save button is enabled
+//    * 3. onClick of save button, submits form values
+//    */
+//   it('should not submit until all required fields are filled out', async () => {
+//     render(<WithValidation />);
+
+//     // Name
+//     userEvent.type(screen.getByLabelText(/hello/i), mockData.name);
+//     expect(screen.getByLabelText(/hello/i)).toHaveValue(mockData);
+//     expect(
+//       screen.getByRole('button', {
+//         name: /form submission/i
+//       })
+//     ).toBeDisabled();
+
+//     // Submit enabled
+//     await waitFor(() =>
+//       expect(
+//         screen.getByRole('button', {
+//           name: /save/i
+//         })
+//       ).toBeEnabled()
+//     );
+
+//     userEvent.click(
+//       screen.getByRole('button', {
+//         name: /save/i
+//       })
+//     );
+
+//     await waitFor(() =>
+//       expect(window.alert).toHaveBeenCalledWith(
+//         JSON.stringify(
+//           {
+//             name: mockData.name
+//           },
+//           null,
+//           2
+//         )
+//       )
+//     );
+//   });
+// });


### PR DESCRIPTION
I wrote some basic tests for SQFormDialog. I didn't want to get too complicated with these because already have tests for SQForm more generally, as well as a lot of our inputs, so I tried to focus on the "dialog" part of things, specifically the `title` prop, the `onSave` and `onClose` callbacks (including the save button enabled/disabled integration with validationSchema), and the auto-focus feature.

As always, any feedback is great, as I'm somewhat new to writing tests.  