### PR TITLE
fix: 🐛 SQFormCheckboxGroup no longer has failed prop error

### DIFF
--- a/stories/SQFormCheckboxGroup.stories.js
+++ b/stories/SQFormCheckboxGroup.stories.js
@@ -37,7 +37,7 @@ const defaultArgs = {
   name: 'shoppingList',
   children: SHOPPING_LIST_OPTIONS,
   SQFormProps: {
-    initialValues: {shoppingList: ''}
+    initialValues: {shoppingList: []}
   }
 };
 


### PR DESCRIPTION
Changed the initial value of the checkbox group in the story to be an
empty array instead of a string

✅ Closes: #273