### PR TITLE
chore: 🤖 Update SQFormCheckbox story initial value

### DIFF
--- a/stories/SQFormCheckboxGroup.stories.js
+++ b/stories/SQFormCheckboxGroup.stories.js
@@ -37,7 +37,7 @@ const defaultArgs = {
   name: 'shoppingList',
   children: SHOPPING_LIST_OPTIONS,
   SQFormProps: {
-    initialValues: {shoppingList: ''}
+    initialValues: {shoppingList: []}
   }
 };
 


### PR DESCRIPTION
Changing the initial value of the checkbox group from a string to an
empty array stops the failed prop error from occurring.

✅ Closes: #273