### PR TITLE
feat: 🎸 adding 20px padding to DialogContent used by the SQFormDialog component

### DIFF
--- a/src/components/SQFormDialog/SQFormDialogInner.js
+++ b/src/components/SQFormDialog/SQFormDialogInner.js
@@ -44,6 +44,12 @@ const useActionsStyles = makeStyles({
     borderTop: ({palette}) => `1px solid ${palette.divider}`
   }
 });
+const useDialogContentStyles = makeStyles({
+  root: {
+    overflowY: 'visible',
+    padding: '20px'
+  }
+});
 
 function SQFormDialogInner({
   cancelButtonText,
@@ -62,6 +68,7 @@ function SQFormDialogInner({
   const theme = useTheme();
   const titleClasses = useTitleStyles(theme);
   const actionsClasses = useActionsStyles(theme);
+  const dialogContentClasses = useDialogContentStyles(theme);
   const {resetForm, dirty: isDirty} = useFormikContext();
 
   const {
@@ -97,7 +104,7 @@ function SQFormDialogInner({
           <DialogTitle disableTypography={true} classes={titleClasses}>
             <Typography variant="h4">{title}</Typography>
           </DialogTitle>
-          <DialogContent style={{overflowY: 'visible'}}>
+          <DialogContent classes={dialogContentClasses}>
             <Grid
               {...muiGridProps}
               container


### PR DESCRIPTION
Adding 20px padding to DialogContent used by the SQFormDialog component.

BREAKING CHANGE: 🧨 Changed SQFormDialog content padding to 20px from 8px 24px

✅ Closes: #88

Loom: https://www.loom.com/share/6ead5c0298f24e4f80533f2d3e05d1af