### PR TITLE
chore: 🤖 Treat ESLint TS warnings as errors for pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "test": "jest --watch",
     "build": "rollup --config && tsc",
-    "lint": "eslint 'src/**/*.{js,ts,tsx}'",
-    "lint.fix": "eslint 'src/**/*.{js,ts,tsx}' --fix",
+    "lint": "eslint --ext .js,.ts,.tsx ./src --max-warnings 0",
+    "lint.fix": "eslint --ext .js,.ts,.tsx ./src --fix",
     "lint.staged": "lint-staged",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook -c .storybook -o .out",
@@ -49,7 +49,7 @@
   "lint-staged": {
     "*.{js,ts,tsx,md}": [
       "prettier --write",
-      "eslint --fix",
+      "npm run lint",
       "git add"
     ]
   },


### PR DESCRIPTION
I ran into this same issue last week on the multi divisional admin TypeScript project.
The ESLint TS related rules would throw warnings for most of its linter rules.
Setting the max number of warnings to 0 will cause a non-zero exit code when warnings occur will allow lint-staged to fail the commit and show the warning/errors like we desire.