### PR TITLE
fix: 🐛 gave autocomplete dropdown tooltips and larger size

### DIFF
--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -347,7 +347,7 @@ SQFormAutocomplete.propTypes = {
   onInputChange: PropTypes.func,
   /** Size of the input given full-width is 12. */
   size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-  /** Lock width to the width of the field in the form */
+  /** Lock width of the dropdown to the width of the field in the form */
   lockWidthToField: PropTypes.bool
 };
 

--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -202,7 +202,7 @@ function SQFormAutocomplete({
   onChange,
   onInputChange,
   size = 'auto',
-  lockWidthToField
+  lockWidthToField = false
 }) {
   const classes = useStyles();
   const gridContainerRef = React.useRef();

--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -69,6 +69,7 @@ function renderRow({data, index, style}) {
       title={value || ''}
       id={`FINDME-${index}`}
       key={`${value}-${index}-with-tooltip`}
+      placement="bottom-start"
     >
       {clone}
     </Tooltip>

--- a/stories/SQForm.stories.js
+++ b/stories/SQForm.stories.js
@@ -186,6 +186,7 @@ export const BasicForm = () => {
           label="Ten Thousand Options"
           size={6}
           onInputChange={action('Update local state')}
+          lockWidthToField
         >
           {MOCK_AUTOCOMPLETE_OPTIONS}
         </SQFormAutocomplete>


### PR DESCRIPTION
Here is the ticket for these changes https://selectquote.atlassian.net/browse/SSC-134

The issue was the autocomplete's dropdown of options was limited to the field's size in the form which caused issues with readability of the options. I increased the width of the dropdown to be 2X the width of the field but with a limit so that it doesn't run off the screen. I also added tooltips to all the options.

**Loom**: https://www.loom.com/share/609c71187ca84dc6925ea88a5652e846
Note: The loom shows the tooltip text in middle of the row, I've updated it to be on the bottom-left so it now shows directly below the value for very large dropdowns.