### PR TITLE
fix: 🐛 bug in SQFormButton to prioritize isDisabled over state

### DIFF
--- a/src/components/SQForm/SQFormButton.js
+++ b/src/components/SQForm/SQFormButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {RoundedButton} from 'scplus-shared-components';
-import {useFormButton} from './useFormButton';
+import {useFormButton, BUTTON_TYPES} from './useFormButton';
 
 function SQFormButton({
   children,
@@ -11,20 +11,13 @@ function SQFormButton({
   type = 'submit',
   onClick
 }) {
-  const isResetButton = type === 'reset';
-  const {dirty, isButtonDisabled, handleReset, handleClick} = useFormButton(
+  const isResetButton = type === BUTTON_TYPES.RESET;
+  const {isButtonDisabled, handleReset, handleClick} = useFormButton(
     isDisabled,
     shouldRequireFieldUpdates,
-    onClick
+    onClick,
+    type
   );
-
-  const isSQFormButtonDisabled = React.useMemo(() => {
-    if (isResetButton) {
-      return !dirty;
-    }
-
-    return isButtonDisabled;
-  }, [dirty, isButtonDisabled, isResetButton]);
 
   const getClickHandler = (...args) => {
     if (isResetButton) {
@@ -49,7 +42,7 @@ function SQFormButton({
     <RoundedButton
       title={getTitle()}
       type={type}
-      isDisabled={isSQFormButtonDisabled}
+      isDisabled={isButtonDisabled}
       onClick={getClickHandler}
       variant={isResetButton ? 'outlined' : 'contained'}
     >
@@ -68,7 +61,7 @@ SQFormButton.propTypes = {
   /** The title of the button */
   title: PropTypes.string,
   /** Type of button, defaults to 'submit' */
-  type: PropTypes.oneOf(['submit', 'reset']),
+  type: PropTypes.oneOf(Object.values(BUTTON_TYPES)),
   /** Standard React event handler */
   onClick: PropTypes.func
 };

--- a/src/components/SQForm/SQFormButton.js
+++ b/src/components/SQForm/SQFormButton.js
@@ -12,12 +12,12 @@ function SQFormButton({
   onClick
 }) {
   const isResetButton = type === BUTTON_TYPES.RESET;
-  const {isButtonDisabled, handleReset, handleClick} = useFormButton(
+  const {isButtonDisabled, handleReset, handleClick} = useFormButton({
     isDisabled,
     shouldRequireFieldUpdates,
     onClick,
-    type
-  );
+    buttonType: type
+  });
 
   const getClickHandler = (...args) => {
     if (isResetButton) {

--- a/src/components/SQForm/SQFormIconButton.js
+++ b/src/components/SQForm/SQFormIconButton.js
@@ -13,12 +13,12 @@ function SQFormIconButton({
   type = BUTTON_TYPES.SUBMIT,
   onClick
 }) {
-  const {isButtonDisabled, handleClick} = useFormButton(
+  const {isButtonDisabled, handleClick} = useFormButton({
     isDisabled,
     shouldRequireFieldUpdates,
     onClick,
-    type
-  );
+    buttonType: type
+  });
 
   function Icon(props) {
     return <IconComponent title={title} {...props} />;

--- a/src/components/SQForm/SQFormIconButton.js
+++ b/src/components/SQForm/SQFormIconButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {useFormButton} from './useFormButton';
+import {useFormButton, BUTTON_TYPES} from './useFormButton';
 import {IconButton} from 'scplus-shared-components';
 
 function SQFormIconButton({
@@ -10,13 +10,14 @@ function SQFormIconButton({
   isDisabled = false,
   shouldRequireFieldUpdates = false,
   title = 'Form Submission',
-  type = 'submit',
+  type = BUTTON_TYPES.SUBMIT,
   onClick
 }) {
   const {isButtonDisabled, handleClick} = useFormButton(
     isDisabled,
     shouldRequireFieldUpdates,
-    onClick
+    onClick,
+    type
   );
 
   function Icon(props) {
@@ -48,7 +49,7 @@ SQFormIconButton.propTypes = {
   /** The title of the button */
   title: PropTypes.string,
   /** Type of button, defaults to 'submit' */
-  type: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(BUTTON_TYPES)),
   /** Standard React event handler */
   onClick: PropTypes.func
 };

--- a/src/components/SQForm/SQFormResetButtonWithConfirmation.js
+++ b/src/components/SQForm/SQFormResetButtonWithConfirmation.js
@@ -14,12 +14,10 @@ function SQFormResetButtonWithConfirmation({
   onReset = () => {}
 }) {
   const {isDialogOpen, openDialog, closeDialog} = useDialog();
-  const {dirty, handleReset} = useFormButton(
+  const {dirty, handleReset} = useFormButton({
     isDisabled,
-    undefined,
-    undefined,
-    BUTTON_TYPES.RESET
-  );
+    buttonType: BUTTON_TYPES.RESET
+  });
 
   const handlePrimaryButtonClick = () => {
     handleReset();

--- a/src/components/SQForm/SQFormResetButtonWithConfirmation.js
+++ b/src/components/SQForm/SQFormResetButtonWithConfirmation.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {useDialog} from '@selectquotelabs/sqhooks';
 import {DialogAlert, RoundedButton} from 'scplus-shared-components';
-import {useFormButton} from './useFormButton';
+import {useFormButton, BUTTON_TYPES} from './useFormButton';
 
 function SQFormResetButtonWithConfirmation({
   children,
@@ -14,7 +14,12 @@ function SQFormResetButtonWithConfirmation({
   onReset = () => {}
 }) {
   const {isDialogOpen, openDialog, closeDialog} = useDialog();
-  const {dirty, handleReset} = useFormButton(isDisabled);
+  const {dirty, handleReset} = useFormButton(
+    isDisabled,
+    undefined,
+    undefined,
+    BUTTON_TYPES.RESET
+  );
 
   const handlePrimaryButtonClick = () => {
     handleReset();

--- a/src/components/SQForm/SQFormResetInitialValuesButton.js
+++ b/src/components/SQForm/SQFormResetInitialValuesButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {useDialog} from '@selectquotelabs/sqhooks';
 import {DialogAlert, TextButton} from 'scplus-shared-components';
-import {useFormButton} from './useFormButton';
+import {useFormButton, BUTTON_TYPES} from './useFormButton';
 
 function SQFormResetInitialValuesButton({
   children,
@@ -15,7 +15,12 @@ function SQFormResetInitialValuesButton({
   ...props
 }) {
   const {isDialogOpen, openDialog, closeDialog} = useDialog();
-  const {values, resetForm} = useFormButton(isDisabled);
+  const {values, resetForm} = useFormButton(
+    isDisabled,
+    undefined,
+    undefined,
+    BUTTON_TYPES.RESET
+  );
 
   const handlePrimaryButtonClick = () => {
     resetForm({

--- a/src/components/SQForm/SQFormResetInitialValuesButton.js
+++ b/src/components/SQForm/SQFormResetInitialValuesButton.js
@@ -15,12 +15,10 @@ function SQFormResetInitialValuesButton({
   ...props
 }) {
   const {isDialogOpen, openDialog, closeDialog} = useDialog();
-  const {values, resetForm} = useFormButton(
+  const {values, resetForm} = useFormButton({
     isDisabled,
-    undefined,
-    undefined,
-    BUTTON_TYPES.RESET
-  );
+    buttonType: BUTTON_TYPES.RESET
+  });
 
   const handlePrimaryButtonClick = () => {
     resetForm({

--- a/src/components/SQForm/useFormButton.js
+++ b/src/components/SQForm/useFormButton.js
@@ -8,12 +8,12 @@ export const BUTTON_TYPES = {
   RESET: 'reset'
 };
 
-export function useFormButton(
-  isDisabled,
-  shouldRequireFieldUpdates,
+export function useFormButton({
+  isDisabled = false,
+  shouldRequireFieldUpdates = false,
   onClick,
   buttonType
-) {
+}) {
   const {values, initialValues, isValid, dirty, ...rest} = useFormikContext();
   const hasFormBeenUpdated = hasUpdated(initialValues, values);
 
@@ -48,10 +48,14 @@ export function useFormButton(
     dirty
   ]);
 
-  const handleClick = useDebouncedCallback((...args) => onClick(...args), 500, {
-    leading: true,
-    trailing: false
-  });
+  const handleClick = useDebouncedCallback(
+    (...args) => onClick?.(...args),
+    500,
+    {
+      leading: true,
+      trailing: false
+    }
+  );
 
   return {
     isButtonDisabled,

--- a/src/components/SQForm/useFormButton.js
+++ b/src/components/SQForm/useFormButton.js
@@ -3,21 +3,50 @@ import {useFormikContext} from 'formik';
 import {useDebouncedCallback} from 'use-debounce';
 import {hasUpdated} from '../../utils';
 
-export function useFormButton(isDisabled, shouldRequireFieldUpdates, onClick) {
-  const {values, initialValues, isValid, ...rest} = useFormikContext();
+export const BUTTON_TYPES = {
+  SUBMIT: 'submit',
+  RESET: 'reset'
+};
+
+export function useFormButton(
+  isDisabled,
+  shouldRequireFieldUpdates,
+  onClick,
+  buttonType
+) {
+  const {values, initialValues, isValid, dirty, ...rest} = useFormikContext();
   const hasFormBeenUpdated = hasUpdated(initialValues, values);
 
   const isButtonDisabled = React.useMemo(() => {
-    if (isDisabled || !isValid) {
+    if (isDisabled) {
       return true;
     }
 
-    if (shouldRequireFieldUpdates && !hasFormBeenUpdated) {
-      return true;
+    if (buttonType === BUTTON_TYPES.SUBMIT) {
+      if (!isValid) {
+        return true;
+      }
+
+      if (shouldRequireFieldUpdates && !hasFormBeenUpdated) {
+        return true;
+      }
+    }
+
+    if (buttonType === BUTTON_TYPES.RESET) {
+      if (!dirty) {
+        return true;
+      }
     }
 
     return false;
-  }, [hasFormBeenUpdated, isDisabled, isValid, shouldRequireFieldUpdates]);
+  }, [
+    hasFormBeenUpdated,
+    isDisabled,
+    isValid,
+    shouldRequireFieldUpdates,
+    buttonType,
+    dirty
+  ]);
 
   const handleClick = useDebouncedCallback((...args) => onClick(...args), 500, {
     leading: true,
@@ -31,6 +60,7 @@ export function useFormButton(isDisabled, shouldRequireFieldUpdates, onClick) {
     initialValues,
     isValid,
     handleClick,
+    dirty,
     ...rest
   };
 }


### PR DESCRIPTION
✅ Closes: #355

Fixed a bug in SQFormButton/useFormButton where the `isDisabled` prop was not used when the button was of type `reset`. Also updated useFormButton to accept an object instead of a multiple params since some params were not always provided.