### PR TITLE
fix: 🐛 Provide task modules context to user onSubmit

### DIFF
--- a/src/components/SQFormGuidedWorkflow/PropTypes.js
+++ b/src/components/SQFormGuidedWorkflow/PropTypes.js
@@ -44,7 +44,7 @@ export const OutcomePropTypes = {
 export const FormikProps = {
   /** Form Entity Object aka initial values of the form */
   initialValues: PropTypes.object.isRequired,
-  /** Form Submission Handler | @typedef onSubmit: (values: Values, formikBag: FormikBag) => void | Promise<any> */
+  /** Form Submission Handler | @typedef onSubmit: (values: Values, formikBag: FormikBag, context) => void | Promise<any> */
   onSubmit: PropTypes.func.isRequired,
   /** Yup validation schema shape */
   validationSchema: PropTypes.object

--- a/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.js
+++ b/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.js
@@ -90,8 +90,15 @@ function SQFormGuidedWorkflow({
       return false;
     };
     const handleSubmit = async (values, formikBag) => {
+      const context = {
+        ...taskModulesContext,
+        [taskNumber]: {
+          ...taskModulesContext[taskNumber],
+          data: values
+        }
+      };
       try {
-        await taskModule.formikProps.onSubmit(values, formikBag);
+        await taskModule.formikProps.onSubmit(values, formikBag, context);
         updateTaskModuleContextByID(taskNumber, values);
         enableNextTaskModule();
       } catch (error) {

--- a/stories/SQFormGuidedWorkflow.stories.js
+++ b/stories/SQFormGuidedWorkflow.stories.js
@@ -38,9 +38,10 @@ const Template = () => {
           outcome: '',
           notes: ''
         },
-        onSubmit: async values => {
+        onSubmit: async (values, _formikBag, context) => {
           await sleep(3000); // Simulate API call to see loading spinner
-          console.log(JSON.stringify(values));
+          console.log(values);
+          console.log(context);
         },
         validationSchema: {
           outcome: Yup.string().required('Required'),
@@ -73,8 +74,9 @@ const Template = () => {
           outcome: '',
           notes: ''
         },
-        onSubmit: async values => {
-          console.log(JSON.stringify(values));
+        onSubmit: async (values, _formikBag, context) => {
+          console.log(values);
+          console.log(context);
         },
         validationSchema: {
           outcome: Yup.string().required('Required'),
@@ -118,8 +120,9 @@ const Template = () => {
           outcome: '',
           notes: ''
         },
-        onSubmit: async values => {
-          console.log(JSON.stringify(values));
+        onSubmit: async (values, _formikBag, context) => {
+          console.log(values);
+          console.log(context);
         },
         validationSchema: {
           outcome: Yup.string().required('Required'),


### PR DESCRIPTION
✅ Closes: #390

This gives the consumer access to the current context of the Guided Workflow when clicking the "Next" button

https://www.loom.com/share/1ce5b19a89d242dd811548166d3a2acb