### PR TITLE
Issue 405/ SQFormGuidedWorkflow skips disabled modules

### DIFF
--- a/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.js
+++ b/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.js
@@ -57,8 +57,7 @@ function SQFormGuidedWorkflow({
 
   const [
     taskModulesContext,
-    updateTaskModuleContextByID,
-    updateModuleDisabledContext
+    updateTaskModuleContextByID
   ] = useGuidedWorkflowContext(taskModules);
 
   const {
@@ -103,7 +102,6 @@ function SQFormGuidedWorkflow({
 
       try {
         await taskModule.formikProps.onSubmit(values, formikBag, context);
-        updateModuleDisabledContext();
         updateTaskModuleContextByID(taskNumber, values);
         enableNextTaskModule();
       } catch (error) {

--- a/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.js
+++ b/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.js
@@ -58,7 +58,7 @@ function SQFormGuidedWorkflow({
   const [
     taskModulesContext,
     updateTaskModuleContextByID,
-    updateTaskModuleContext
+    updateModuleDisabledContext
   ] = useGuidedWorkflowContext(taskModules);
 
   const {
@@ -103,7 +103,7 @@ function SQFormGuidedWorkflow({
 
       try {
         await taskModule.formikProps.onSubmit(values, formikBag, context);
-        updateTaskModuleContext();
+        updateModuleDisabledContext();
         updateTaskModuleContextByID(taskNumber, values);
         enableNextTaskModule();
       } catch (error) {

--- a/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.js
+++ b/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.js
@@ -77,10 +77,13 @@ function SQFormGuidedWorkflow({
     );
     const isPanelExpanded =
       taskModulesContext[taskModulesState.activeTaskModuleID].name === taskName;
+
     const getIsDisabled = () => {
+      console.log('taskNumber', taskNumber);
       if (isStrictMode && taskModulesState.activeTaskModuleID !== taskNumber) {
         return true;
       }
+      console.log('taskModule.isDisabled', taskModule.isDisabled);
       if (
         taskModule.isDisabled ||
         taskModulesState.progressTaskModuleID < taskNumber
@@ -89,6 +92,7 @@ function SQFormGuidedWorkflow({
       }
       return false;
     };
+
     const handleSubmit = async (values, formikBag) => {
       const context = {
         ...taskModulesContext,
@@ -97,9 +101,18 @@ function SQFormGuidedWorkflow({
           data: values
         }
       };
+      console.log('handleSubmit context', context);
       try {
         await taskModule.formikProps.onSubmit(values, formikBag, context);
-        updateTaskModuleContextByID(taskNumber, values);
+        console.log(
+          'handleSubmit taskModulesContext[taskNumber].isDisabled',
+          taskModulesContext[taskNumber].isDisabled
+        );
+        updateTaskModuleContextByID(
+          taskNumber,
+          values,
+          taskModulesContext[taskNumber].isDisabled
+        );
         enableNextTaskModule();
       } catch (error) {
         onError(error);

--- a/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.js
+++ b/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.js
@@ -57,7 +57,8 @@ function SQFormGuidedWorkflow({
 
   const [
     taskModulesContext,
-    updateTaskModuleContextByID
+    updateTaskModuleContextByID,
+    updateTaskModuleContext
   ] = useGuidedWorkflowContext(taskModules);
 
   const {
@@ -79,11 +80,9 @@ function SQFormGuidedWorkflow({
       taskModulesContext[taskModulesState.activeTaskModuleID].name === taskName;
 
     const getIsDisabled = () => {
-      console.log('taskNumber', taskNumber);
       if (isStrictMode && taskModulesState.activeTaskModuleID !== taskNumber) {
         return true;
       }
-      console.log('taskModule.isDisabled', taskModule.isDisabled);
       if (
         taskModule.isDisabled ||
         taskModulesState.progressTaskModuleID < taskNumber
@@ -101,18 +100,11 @@ function SQFormGuidedWorkflow({
           data: values
         }
       };
-      console.log('handleSubmit context', context);
+
       try {
         await taskModule.formikProps.onSubmit(values, formikBag, context);
-        console.log(
-          'handleSubmit taskModulesContext[taskNumber].isDisabled',
-          taskModulesContext[taskNumber].isDisabled
-        );
-        updateTaskModuleContextByID(
-          taskNumber,
-          values,
-          taskModulesContext[taskNumber].isDisabled
-        );
+        updateTaskModuleContext();
+        updateTaskModuleContextByID(taskNumber, values);
         enableNextTaskModule();
       } catch (error) {
         onError(error);

--- a/src/components/SQFormGuidedWorkflow/useGuidedWorkflowContext.js
+++ b/src/components/SQFormGuidedWorkflow/useGuidedWorkflowContext.js
@@ -15,21 +15,15 @@ export function useGuidedWorkflowContext(taskModules) {
   const reducer = (prevState, action) => {
     switch (action.type) {
       case 'UPDATE':
-        return {
-          ...prevState,
-          [action.id]: {
-            ...prevState[action.id],
-            data: action.data
-          }
-        };
-      case 'UPDATE_DISABLED_STATUS':
-        return taskModules.reduce((acc, taskModule, index) => {
+        return taskModules.reduce((acc, taskModlue, index) => {
+          const taskID = index + 1;
+          const prevData = prevState[taskID].data;
           return {
             ...acc,
-            [index + 1]: {
-              name: taskModule.name,
-              data: prevState[index + 1].data,
-              isDisabled: taskModule.isDisabled || false
+            [taskID]: {
+              name: taskModlue.name,
+              data: action.id === taskID ? action.data : prevData,
+              isDisabled: taskModlue.isDisabled || false
             }
           };
         }, {});
@@ -46,9 +40,5 @@ export function useGuidedWorkflowContext(taskModules) {
     dispatch({type: 'UPDATE', id, data});
   };
 
-  const updateDisabledModules = () => {
-    dispatch({type: 'UPDATE_DISABLED_STATUS'});
-  };
-
-  return [state, updateDataByID, updateDisabledModules];
+  return [state, updateDataByID];
 }

--- a/src/components/SQFormGuidedWorkflow/useGuidedWorkflowContext.js
+++ b/src/components/SQFormGuidedWorkflow/useGuidedWorkflowContext.js
@@ -19,9 +19,13 @@ export function useGuidedWorkflowContext(taskModules) {
           ...prevState,
           [action.id]: {
             ...prevState[action.id],
-            data: action.data,
-            isDisabled: action.isDisabled
+            data: action.data
           }
+        };
+      case 'UPDATE_MODULES':
+        return {
+          ...prevState,
+          ...initialData
         };
       default:
         throw new Error(
@@ -32,10 +36,13 @@ export function useGuidedWorkflowContext(taskModules) {
 
   const [state, dispatch] = React.useReducer(reducer, initialData);
 
-  const updateDataByID = (id, data, isDisabled) => {
-    console.log('updateDataByID', id, data, isDisabled);
-    dispatch({type: 'UPDATE', id, data, isDisabled});
+  const updateDataByID = (id, data) => {
+    dispatch({type: 'UPDATE', id, data});
   };
 
-  return [state, updateDataByID];
+  const updateTaskModules = () => {
+    dispatch({type: 'UPDATE_MODULES'});
+  };
+
+  return [state, updateDataByID, updateTaskModules];
 }

--- a/src/components/SQFormGuidedWorkflow/useGuidedWorkflowContext.js
+++ b/src/components/SQFormGuidedWorkflow/useGuidedWorkflowContext.js
@@ -23,10 +23,16 @@ export function useGuidedWorkflowContext(taskModules) {
           }
         };
       case 'UPDATE_MODULES':
-        return {
-          ...prevState,
-          ...initialData
-        };
+        return taskModules.reduce((acc, taskModule, index) => {
+          return {
+            ...acc,
+            [index + 1]: {
+              name: taskModule.name,
+              data: prevState[index + 1].data,
+              isDisabled: taskModule.isDisabled || false
+            }
+          };
+        }, {});
       default:
         throw new Error(
           `The ${action.type} type provided to useGuidedWorkflow is not valid`

--- a/src/components/SQFormGuidedWorkflow/useGuidedWorkflowContext.js
+++ b/src/components/SQFormGuidedWorkflow/useGuidedWorkflowContext.js
@@ -22,7 +22,7 @@ export function useGuidedWorkflowContext(taskModules) {
             data: action.data
           }
         };
-      case 'UPDATE_MODULES':
+      case 'UPDATE_DISABLED_STATUS':
         return taskModules.reduce((acc, taskModule, index) => {
           return {
             ...acc,
@@ -46,9 +46,9 @@ export function useGuidedWorkflowContext(taskModules) {
     dispatch({type: 'UPDATE', id, data});
   };
 
-  const updateTaskModules = () => {
-    dispatch({type: 'UPDATE_MODULES'});
+  const updateDisabledModules = () => {
+    dispatch({type: 'UPDATE_DISABLED_STATUS'});
   };
 
-  return [state, updateDataByID, updateTaskModules];
+  return [state, updateDataByID, updateDisabledModules];
 }

--- a/src/components/SQFormGuidedWorkflow/useGuidedWorkflowContext.js
+++ b/src/components/SQFormGuidedWorkflow/useGuidedWorkflowContext.js
@@ -6,7 +6,8 @@ export function useGuidedWorkflowContext(taskModules) {
       ...acc,
       [index + 1]: {
         name: taskModule.name,
-        data: taskModule.formikProps.initialValues
+        data: taskModule.formikProps.initialValues,
+        isDisabled: taskModule.isDisabled || false
       }
     };
   }, {});
@@ -18,7 +19,8 @@ export function useGuidedWorkflowContext(taskModules) {
           ...prevState,
           [action.id]: {
             ...prevState[action.id],
-            data: action.data
+            data: action.data,
+            isDisabled: action.isDisabled
           }
         };
       default:
@@ -30,8 +32,9 @@ export function useGuidedWorkflowContext(taskModules) {
 
   const [state, dispatch] = React.useReducer(reducer, initialData);
 
-  const updateDataByID = (id, data) => {
-    dispatch({type: 'UPDATE', id, data});
+  const updateDataByID = (id, data, isDisabled) => {
+    console.log('updateDataByID', id, data, isDisabled);
+    dispatch({type: 'UPDATE', id, data, isDisabled});
   };
 
   return [state, updateDataByID];

--- a/src/components/SQFormGuidedWorkflow/useManageTaskModules.js
+++ b/src/components/SQFormGuidedWorkflow/useManageTaskModules.js
@@ -80,7 +80,12 @@ export function useManageTaskModules(
 
     const updateActiveTaskModuleID = id => {
       if (isTaskDisabled(id)) {
-        return {...prevState, activeTaskModuleID: findNextTask(id)};
+        const nextID = findNextTask(id);
+        return {
+          ...prevState,
+          activeTaskModuleID: nextID,
+          progressTaskModuleID: nextID
+        };
       }
       return {...prevState, activeTaskModuleID: id};
     };
@@ -92,7 +97,6 @@ export function useManageTaskModules(
         if (prevState.activeTaskModuleID === prevState.progressTaskModuleID) {
           return enableNextTaskModule();
         }
-
         return updateActiveTaskModuleID(prevState.progressTaskModuleID);
       case 'RESET_TO_INITIAL_STATE':
         return initialState;

--- a/src/components/SQFormGuidedWorkflow/useManageTaskModules.js
+++ b/src/components/SQFormGuidedWorkflow/useManageTaskModules.js
@@ -40,7 +40,6 @@ export function useManageTaskModules(
       }
 
       const nextTaskID = prevTaskID + 1;
-      //const nextTask = taskModulesContext[nextTaskID];
 
       if (isTaskDisabled(nextTaskID)) {
         return findNextTask(nextTaskID);
@@ -80,10 +79,7 @@ export function useManageTaskModules(
     };
 
     const updateActiveTaskModuleID = id => {
-      console.log('taskModulesContext', taskModulesContext);
-      console.log('isTaskDisabled(id)', isTaskDisabled(id));
       if (isTaskDisabled(id)) {
-        console.log('findNextTask(id)', findNextTask(id));
         return {...prevState, activeTaskModuleID: findNextTask(id)};
       }
       return {...prevState, activeTaskModuleID: id};

--- a/src/components/SQFormGuidedWorkflow/useManageTaskModules.js
+++ b/src/components/SQFormGuidedWorkflow/useManageTaskModules.js
@@ -34,7 +34,7 @@ export function useManageTaskModules(
       return taskModulesContext[taskID].isDisabled;
     };
 
-    const findNextTask = prevTaskID => {
+    const findNextTaskID = prevTaskID => {
       if (isTaskIDTheFinalTask(prevTaskID)) {
         return;
       }
@@ -42,7 +42,7 @@ export function useManageTaskModules(
       const nextTaskID = prevTaskID + 1;
 
       if (isTaskDisabled(nextTaskID)) {
-        return findNextTask(nextTaskID);
+        return findNextTaskID(nextTaskID);
       }
 
       return nextTaskID;
@@ -53,7 +53,7 @@ export function useManageTaskModules(
         return prevTaskID;
       }
 
-      const nextTaskModuleID = findNextTask(prevTaskID);
+      const nextTaskModuleID = findNextTaskID(prevTaskID);
 
       if (nextTaskModuleID) {
         return nextTaskModuleID;
@@ -79,25 +79,27 @@ export function useManageTaskModules(
     };
 
     const updateActiveTaskModuleID = id => {
-      if (isTaskDisabled(id)) {
-        const nextID = findNextTask(id);
+      const nextID = findNextTaskID(id);
+
+      if (isTaskDisabled(nextID)) {
+        const nextTaskID = findNextTaskID(nextID);
         return {
           ...prevState,
-          activeTaskModuleID: nextID,
-          progressTaskModuleID: nextID
+          activeTaskModuleID: nextTaskID,
+          progressTaskModuleID: nextTaskID
         };
       }
-      return {...prevState, activeTaskModuleID: id};
+      return {...prevState, activeTaskModuleID: nextID};
     };
 
     switch (action.type) {
       case 'UPDATE_ACTIVE_TASK_MODULE':
-        return updateActiveTaskModuleID(action.id);
+        return {...prevState, activeTaskModuleID: action.id};
       case 'ENABLE_NEXT_TASK_MODULE':
         if (prevState.activeTaskModuleID === prevState.progressTaskModuleID) {
           return enableNextTaskModule();
         }
-        return updateActiveTaskModuleID(prevState.progressTaskModuleID);
+        return updateActiveTaskModuleID(prevState.activeTaskModuleID);
       case 'RESET_TO_INITIAL_STATE':
         return initialState;
       default:

--- a/src/components/SQFormGuidedWorkflow/useManageTaskModules.js
+++ b/src/components/SQFormGuidedWorkflow/useManageTaskModules.js
@@ -30,11 +30,37 @@ export function useManageTaskModules(
       return prevTaskID === taskModulesLength;
     };
 
+    const isTaskDisabled = taskID => {
+      return taskModulesContext[taskID].isDisabled;
+    };
+
+    const findNextTask = prevTaskID => {
+      if (isTaskIDTheFinalTask(prevTaskID)) {
+        return;
+      }
+
+      const nextTaskID = prevTaskID + 1;
+      //const nextTask = taskModulesContext[nextTaskID];
+
+      if (isTaskDisabled(nextTaskID)) {
+        return findNextTask(nextTaskID);
+      }
+
+      return nextTaskID;
+    };
+
     const incrementTaskModuleID = prevTaskID => {
       if (isTaskIDTheFinalTask(prevTaskID)) {
         return prevTaskID;
       }
-      return (prevTaskID += 1);
+
+      const nextTaskModuleID = findNextTask(prevTaskID);
+
+      if (nextTaskModuleID) {
+        return nextTaskModuleID;
+      }
+
+      return prevTaskID;
     };
 
     const incrementActiveTaskModuleID = () => {
@@ -54,6 +80,12 @@ export function useManageTaskModules(
     };
 
     const updateActiveTaskModuleID = id => {
+      console.log('taskModulesContext', taskModulesContext);
+      console.log('isTaskDisabled(id)', isTaskDisabled(id));
+      if (isTaskDisabled(id)) {
+        console.log('findNextTask(id)', findNextTask(id));
+        return {...prevState, activeTaskModuleID: findNextTask(id)};
+      }
       return {...prevState, activeTaskModuleID: id};
     };
 
@@ -64,6 +96,7 @@ export function useManageTaskModules(
         if (prevState.activeTaskModuleID === prevState.progressTaskModuleID) {
           return enableNextTaskModule();
         }
+
         return updateActiveTaskModuleID(prevState.progressTaskModuleID);
       case 'RESET_TO_INITIAL_STATE':
         return initialState;

--- a/stories/SQFormGuidedWorkflow.stories.js
+++ b/stories/SQFormGuidedWorkflow.stories.js
@@ -64,13 +64,6 @@ const Template = () => {
             <SQFormDropdown name="outcome" label="Outcome" isRequired={true}>
               {outcomeDropdownOptions}
             </SQFormDropdown>
-            <RoundedButton
-              title="Test Disable"
-              onClick={() => setIsModuleDisabled(true)}
-            >
-              Test Disable
-            </RoundedButton>
-            <RoundedButton>{`${isModuleDisabled}`}</RoundedButton>
             <SQFormTextarea name="notes" label="Notes" />
           </>
         ),
@@ -79,7 +72,9 @@ const Template = () => {
     },
     {
       name: 'cancellation',
-      title: 'Policy Cancellation Statement',
+      title: isModuleDisabled
+        ? 'Dont Verify Providers'
+        : 'Policy Cancellation Statement',
       subtitles: ['Cancelling policy'],
       isFailedState: isIneligible,
       isDisabled: isModuleDisabled,
@@ -127,11 +122,8 @@ const Template = () => {
     },
     {
       name: 'providers',
-      title: isModuleDisabled ? 'Dont Verify Providers' : 'Verify Providers',
-      subtitles: [
-        'Please verify the providers',
-        isModuleDisabled ? 'Disabled' : 'Not Disabled'
-      ],
+      title: 'Verify Providers',
+      subtitles: ['Please verify the providers'],
       isDisabled: true,
       formikProps: {
         initialValues: {

--- a/stories/SQFormGuidedWorkflow.stories.js
+++ b/stories/SQFormGuidedWorkflow.stories.js
@@ -124,7 +124,7 @@ const Template = () => {
       name: 'providers',
       title: 'Verify Providers',
       subtitles: ['Please verify the providers'],
-      isDisabled: true,
+      isDisabled: false,
       formikProps: {
         initialValues: {
           outcome: '',
@@ -155,40 +155,6 @@ const Template = () => {
           </>
         ),
         title: 'Confirm Info'
-      }
-    },
-    {
-      name: 'yetAnother',
-      title: 'Yet Another Test',
-      subtitles: ['Testing . . .'],
-      formikProps: {
-        initialValues: {
-          outcome: '',
-          notes: ''
-        },
-        onSubmit: async (values, _formikBag, context) => {
-          console.log(values);
-          console.log(context);
-        },
-        validationSchema: {
-          outcome: Yup.string().required('Required'),
-          notes: Yup.string()
-        }
-      },
-      scriptedTextProps: {
-        text: 'Scripted Text goes here',
-        title: 'Title of the Script'
-      },
-      outcomeProps: {
-        FormElements: (
-          <>
-            <SQFormDropdown name="outcome" label="Outcome" isRequired={true}>
-              {outcomeDropdownOptions}
-            </SQFormDropdown>
-            <SQFormTextarea name="notes" label="Notes" />
-          </>
-        ),
-        title: 'Last Info'
       }
     }
   ];

--- a/stories/SQFormGuidedWorkflow.stories.js
+++ b/stories/SQFormGuidedWorkflow.stories.js
@@ -24,6 +24,7 @@ const outcomeDropdownOptions = [
 
 const Template = () => {
   const [isIneligible, setIneligible] = React.useState(false);
+  const [isModuleDisabled, setIsModuleDisabled] = React.useState(false);
   const scriptedTextMap = {
     customerName: 'Bob Smith',
     agentName: 'Jane Doe',
@@ -42,6 +43,11 @@ const Template = () => {
           await sleep(3000); // Simulate API call to see loading spinner
           console.log(values);
           console.log(context);
+          if (values.outcome === 'not-interested') {
+            setIsModuleDisabled(true);
+          } else {
+            setIsModuleDisabled(false);
+          }
         },
         validationSchema: {
           outcome: Yup.string().required('Required'),
@@ -58,6 +64,13 @@ const Template = () => {
             <SQFormDropdown name="outcome" label="Outcome" isRequired={true}>
               {outcomeDropdownOptions}
             </SQFormDropdown>
+            <RoundedButton
+              title="Test Disable"
+              onClick={() => setIsModuleDisabled(true)}
+            >
+              Test Disable
+            </RoundedButton>
+            <RoundedButton>{`${isModuleDisabled}`}</RoundedButton>
             <SQFormTextarea name="notes" label="Notes" />
           </>
         ),
@@ -69,6 +82,7 @@ const Template = () => {
       title: 'Policy Cancellation Statement',
       subtitles: ['Cancelling policy'],
       isFailedState: isIneligible,
+      isDisabled: isModuleDisabled,
       formikProps: {
         initialValues: {
           outcome: '',
@@ -113,8 +127,12 @@ const Template = () => {
     },
     {
       name: 'providers',
-      title: 'Verify Providers',
-      subtitles: ['Please verify the providers'],
+      title: isModuleDisabled ? 'Dont Verify Providers' : 'Verify Providers',
+      subtitles: [
+        'Please verify the providers',
+        isModuleDisabled ? 'Disabled' : 'Not Disabled'
+      ],
+      isDisabled: true,
       formikProps: {
         initialValues: {
           outcome: '',
@@ -145,6 +163,40 @@ const Template = () => {
           </>
         ),
         title: 'Confirm Info'
+      }
+    },
+    {
+      name: 'yetAnother',
+      title: 'Yet Another Test',
+      subtitles: ['Testing . . .'],
+      formikProps: {
+        initialValues: {
+          outcome: '',
+          notes: ''
+        },
+        onSubmit: async (values, _formikBag, context) => {
+          console.log(values);
+          console.log(context);
+        },
+        validationSchema: {
+          outcome: Yup.string().required('Required'),
+          notes: Yup.string()
+        }
+      },
+      scriptedTextProps: {
+        text: 'Scripted Text goes here',
+        title: 'Title of the Script'
+      },
+      outcomeProps: {
+        FormElements: (
+          <>
+            <SQFormDropdown name="outcome" label="Outcome" isRequired={true}>
+              {outcomeDropdownOptions}
+            </SQFormDropdown>
+            <SQFormTextarea name="notes" label="Notes" />
+          </>
+        ),
+        title: 'Last Info'
       }
     }
   ];


### PR DESCRIPTION
Before if you passed in isDisabled to a task module, it would still open
the module and let you make changes. Now enabling the next module will
skip disabled modules until it finds the next enabled one or it reaches
the end.

Loom showing updates: https://www.loom.com/share/5a3616d36a6c494897043a63510aabd5