### PR TITLE
fix: 🐛 fixed autocomplete initial width issues and placement

### DIFF
--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -276,7 +276,7 @@ function SQFormAutocomplete({
         name={name}
         style={{width: '100%'}}
         disableListWrap
-        disablePortal
+        disablePortal={!lockWidthToField}
         classes={autocompleteClasses}
         ListboxComponent={ListboxVirtualizedComponent}
         // Note: basewidth is not camel cased because React doesn't like it here

--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -18,27 +18,6 @@ const LISTBOX_PADDING = 8; // px
 
 const EMPTY_OPTION = {label: '- -', value: ''};
 
-const useStyles = makeStyles({
-  listbox: {
-    width: 'initial !important',
-    overflowX: 'hidden !important',
-
-    '& ul': {
-      padding: 0,
-      margin: 0
-    }
-  },
-  popper: {
-    borderRadius: '4px',
-    boxShadow: '0px 3px 4px 0px rgb(100 100 100)',
-    width: 'initial !important',
-    overflowX: 'hidden !important'
-  },
-  paper: {
-    margin: 0
-  }
-});
-
 const OuterElementContext = React.createContext({});
 
 const OuterElementType = React.forwardRef((props, ref) => {
@@ -67,7 +46,6 @@ function renderRow({data, index, style}) {
   return (
     <Tooltip
       title={value || ''}
-      id={`FINDME-${index}`}
       key={`${value}-${index}-with-tooltip`}
       placement="bottom-start"
     >
@@ -134,7 +112,6 @@ const ListboxVirtualizedComponent = React.forwardRef(
             className={classes.list}
             itemData={items}
             height={height}
-            width="auto"
             key={ITEM_COUNT}
             outerElementType={OuterElementType}
             innerElementType="ul"
@@ -191,6 +168,32 @@ const calculateBaseWidth = ref => {
   return baseWidth;
 };
 
+const useStyles = makeStyles({
+  grid: {
+    position: 'relative'
+  }
+});
+
+const useAutocompleteStyles = makeStyles({
+  listbox: {
+    overflowX: 'hidden !important',
+
+    '& ul': {
+      padding: 0,
+      margin: 0
+    }
+  },
+  popper: {
+    borderRadius: '4px',
+    boxShadow: '0px 3px 4px 0px rgb(100 100 100)',
+    width: 'auto !important',
+    overflowX: 'hidden !important'
+  },
+  paper: {
+    margin: 0
+  }
+});
+
 function SQFormAutocomplete({
   children,
   isDisabled = false,
@@ -202,9 +205,11 @@ function SQFormAutocomplete({
   onChange,
   onInputChange,
   size = 'auto',
-  lockWidthToField = false
+  lockWidthToField = true
 }) {
   const classes = useStyles();
+  const autocompleteClasses = useAutocompleteStyles();
+
   const gridContainerRef = React.useRef();
   const baseWidth = calculateBaseWidth(gridContainerRef.current);
   const left = gridContainerRef.current?.getBoundingClientRect().left;
@@ -265,14 +270,14 @@ function SQFormAutocomplete({
   const options = displayEmpty ? [EMPTY_OPTION, ...children] : children;
 
   return (
-    <Grid item sm={size} ref={gridContainerRef}>
+    <Grid item sm={size} ref={gridContainerRef} className={classes.grid}>
       <Autocomplete
         id={name}
         name={name}
         style={{width: '100%'}}
         disableListWrap
         disablePortal
-        classes={classes}
+        classes={autocompleteClasses}
         ListboxComponent={ListboxVirtualizedComponent}
         // Note: basewidth is not camel cased because React doesn't like it here
         ListboxProps={{basewidth: baseWidth, left, lockWidthToField}}

--- a/stories/SQForm.stories.js
+++ b/stories/SQForm.stories.js
@@ -186,7 +186,7 @@ export const BasicForm = () => {
           label="Ten Thousand Options"
           size={6}
           onInputChange={action('Update local state')}
-          lockWidthToField
+          lockWidthToField={false}
         >
           {MOCK_AUTOCOMPLETE_OPTIONS}
         </SQFormAutocomplete>

--- a/stories/SQFormAutocomplete.stories.js
+++ b/stories/SQFormAutocomplete.stories.js
@@ -83,3 +83,9 @@ WithValidation.args = {
 WithValidation.parameters = {
   controls: {exclude: 'schema'}
 };
+
+export const WithAutoSizePopper = Template.bind({});
+WithAutoSizePopper.args = {
+  ...defaultArgs,
+  lockWidthToField: false
+};


### PR DESCRIPTION
Autocomplete should now have the correct width on first render and the popover should more reliably render below the field.
✅ Closes: #429

I was not able to replicate the issues mentioned in #429 as far as the positioning of the popover being in really weird places. Since the popover is positioned absolutely the only thing I can think of as to why it happens sometimes and not others is that some ancestor has some css that is throwing off the absolute positioning of the popover. So I added relative positioning to the grid item that contains the autocomplete and the popover so hopefully that lets the absolutely positioned popover render properly. Also, the default for lockWidthToField is now `true`, I think that maintains backwards compatibility better. An additional advantage to this however, is that when lockWidthToField is true we can re-enable react portal for the popover which should eliminate the absolute position issues in those cases entirely.