### PR TITLE
fix: 🐛 fix isSelfBounding issue in SQFormScrollableCard

### DIFF
--- a/src/components/SQFormScrollableCard/SQFormScrollableCard.js
+++ b/src/components/SQFormScrollableCard/SQFormScrollableCard.js
@@ -11,7 +11,6 @@ import {
 } from '@material-ui/core';
 import {Formik, Form} from 'formik';
 import {useDebouncedCallback} from 'use-debounce';
-import {useAutoHeight} from '@selectquotelabs/sqhooks';
 import SQFormButton from '../SQForm/SQFormButton';
 import SQFormHelperText from '../SQForm/SQFormHelperText';
 import {useInitialRequiredErrors} from '../../hooks/useInitialRequiredErrors';
@@ -77,7 +76,6 @@ function SQFormScrollableCard({
   validationSchema,
   isHeaderDisabled = false
 }) {
-  const {containerRef, height: autoHeight} = useAutoHeight();
   const hasSubHeader = Boolean(SubHeaderComponent);
 
   const validationYupSchema = React.useMemo(() => {
@@ -100,13 +98,33 @@ function SQFormScrollableCard({
     title
   ]);
 
-  const heightToUse = height || (isSelfBounding && autoHeight) || '100%';
+  const [calculatedHeight, setCalculatedHeight] = React.useState(0);
+
+  React.useEffect(() => {
+    const currentElement = document.getElementById(
+      `sqform-scrollable-card-id-${formattedTitle}`
+    );
+
+    const topOffset = currentElement?.getBoundingClientRect().top;
+    const offsetBasedHeight = `calc(100vh - ${topOffset}px - 24px)`;
+
+    const parentHeight = currentElement.parentElement.clientHeight;
+    const parentTopOffset = currentElement.parentElement.getBoundingClientRect()
+      .top;
+    const topDifferential = topOffset - parentTopOffset;
+    const maxOffsetBasedHeight = `calc(${parentHeight}px - ${topDifferential}px)`;
+
+    const calculatedHeight = `min(${offsetBasedHeight}, ${maxOffsetBasedHeight})`;
+
+    setCalculatedHeight(calculatedHeight);
+  }, [formattedTitle]);
+
+  const heightToUse = height || (isSelfBounding && calculatedHeight) || '100%';
 
   return (
     <div
       id={`sqform-scrollable-card-id-${formattedTitle}`}
       style={{height: heightToUse}}
-      ref={containerRef}
     >
       <Formik
         enableReinitialize={enableReinitialize}

--- a/stories/SQFormScrollableCardsMenuWrapper.stories.js
+++ b/stories/SQFormScrollableCardsMenuWrapper.stories.js
@@ -43,27 +43,6 @@ function ScrollableDetails() {
     actions.resetForm();
   };
 
-  /**
-   * TODO: This code can/should be removed once this issue is resolved - https://github.com/SelectQuoteLabs/SQForm/issues/436
-   * Once this problem is resolved, we can remove this code block below and also remove the wrapper container around our SQFormScrollableCard
-   */
-  const [calculatedHeight, setCalculatedHeight] = React.useState(0);
-
-  React.useEffect(() => {
-    const currentElement = document.getElementById(`ResultContainer`);
-    const topOffset = currentElement?.getBoundingClientRect().top;
-    const offsetBasedHeight = `calc(100vh - ${topOffset}px - 24px)`;
-    const parentHeight = currentElement?.parentElement?.clientHeight;
-    const parentTopOffset = currentElement?.parentElement?.getBoundingClientRect()
-      .top;
-    const topDifferential =
-      topOffset && parentTopOffset ? topOffset - parentTopOffset : 0;
-    const maxOffsetBasedHeight = `calc(${parentHeight}px - ${topDifferential}px)`;
-    const calculatedContainerHeight = `min(${offsetBasedHeight}, ${maxOffsetBasedHeight})`;
-
-    setCalculatedHeight(calculatedContainerHeight);
-  }, []);
-
   return (
     <SQFormScrollableCard
       isHeaderDisabled={true}
@@ -71,7 +50,6 @@ function ScrollableDetails() {
       onSubmit={handleSubmit}
       shouldRequireFieldUpdates={true}
       validationSchema={validationSchema}
-      height={calculatedHeight}
       title="notApplicableBecauseHeaderDisabled" // bug in SQFormScrollableCard bc it errors if no title prop even though it doesn't render its cardheader
     >
       <SQFormTextField
@@ -98,26 +76,6 @@ function ScrollablePermissions() {
     actions.setSubmitting(false);
     actions.resetForm();
   };
-  /**
-   * TODO: This code can/should be removed once this issue is resolved - https://github.com/SelectQuoteLabs/SQForm/issues/436
-   * Once this problem is resolved, we can remove this code block below and also remove the wrapper container around our SQFormScrollableCard
-   */
-  const [calculatedHeight, setCalculatedHeight] = React.useState(0);
-
-  React.useEffect(() => {
-    const currentElement = document.getElementById(`ResultContainer`);
-    const topOffset = currentElement?.getBoundingClientRect().top;
-    const offsetBasedHeight = `calc(100vh - ${topOffset}px - 24px)`;
-    const parentHeight = currentElement?.parentElement?.clientHeight;
-    const parentTopOffset = currentElement?.parentElement?.getBoundingClientRect()
-      .top;
-    const topDifferential =
-      topOffset && parentTopOffset ? topOffset - parentTopOffset : 0;
-    const maxOffsetBasedHeight = `calc(${parentHeight}px - ${topDifferential}px)`;
-    const calculatedContainerHeight = `min(${offsetBasedHeight}, ${maxOffsetBasedHeight})`;
-
-    setCalculatedHeight(calculatedContainerHeight);
-  }, []);
 
   return (
     <SQFormScrollableCard
@@ -126,7 +84,6 @@ function ScrollablePermissions() {
       onSubmit={handleSubmit}
       shouldRequireFieldUpdates={true}
       validationSchema={validationSchema}
-      height={calculatedHeight}
       title="notApplicableBecauseHeaderDisabled"
     >
       <SQFormCheckbox name="isAdmin" label="Admin" size={12} />

--- a/stories/SQFormScrollableCardsMenuWrapper.stories.js
+++ b/stories/SQFormScrollableCardsMenuWrapper.stories.js
@@ -46,6 +46,7 @@ function ScrollableDetails() {
   return (
     <SQFormScrollableCard
       isHeaderDisabled={true}
+      isSelfBounding={true}
       initialValues={initialValues}
       onSubmit={handleSubmit}
       shouldRequireFieldUpdates={true}
@@ -80,6 +81,7 @@ function ScrollablePermissions() {
   return (
     <SQFormScrollableCard
       isHeaderDisabled={true}
+      isSelfBounding={true}
       initialValues={initialValues}
       onSubmit={handleSubmit}
       shouldRequireFieldUpdates={true}


### PR DESCRIPTION
✅ Closes: 436

I know this is probably not the ideal solution to the problem, but SQFormScrollableCard is pretty critical to MIAV and we need to address the issue with `isSelfBounding` not working and causing us to write more custom add-on stuff inside the MIAV. We know the code proposed here works, and consuming `useAutoHeight` with other components seems to work as expected, but we've investigated this issue within SQFormScrollableCard and cannot seem to figure it out. Our short term solution is to go back to what worked before. In the future, we can devote more time to figuring out why `useAutoHeight` doesn't work in this particular case, but this PR gets folks a working SQFormScrollableCard.