### PR TITLE
refactor: 💡 remove unnecessary prop - SQFormScrollableCard

### DIFF
--- a/src/components/SQFormScrollableCard/SQFormScrollableCard.js
+++ b/src/components/SQFormScrollableCard/SQFormScrollableCard.js
@@ -7,7 +7,7 @@ import {
   CardContent,
   CardActions,
   Grid,
-  makeStyles
+  makeStyles,
 } from '@material-ui/core';
 import {Formik, Form} from 'formik';
 import {useDebouncedCallback} from 'use-debounce';
@@ -15,42 +15,42 @@ import SQFormButton from '../SQForm/SQFormButton';
 import SQFormHelperText from '../SQForm/SQFormHelperText';
 import {useInitialRequiredErrors} from '../../hooks/useInitialRequiredErrors';
 
-const useStyles = makeStyles(theme => {
+const useStyles = makeStyles((theme) => {
   return {
     form: {
       height: '100%',
-      width: '100%'
+      width: '100%',
     },
     card: {
       display: 'grid',
       gridTemplateColumns: '1fr',
       gridTemplateRows: 'auto 1fr auto',
       gridTemplateAreas: `'header' 'content' 'footer'`,
-      height: '100%'
+      height: '100%',
     },
     cardHeader: {
       gridArea: 'header',
       borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
-      padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`
+      padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
     },
     cardContent: {
       gridArea: 'content',
       overflowY: 'auto',
-      padding: `${theme.spacing(2)}px`
+      padding: `${theme.spacing(2)}px`,
     },
     childrenContainer: {
       width: 'auto',
       margin: ({hasSubHeader}) => {
         return hasSubHeader ? `${theme.spacing(2)}px ${theme.spacing(4)}px` : 0;
-      }
+      },
     },
     cardFooter: {
       gridArea: 'footer',
       display: 'flex',
       justifyContent: 'space-between',
       borderTop: '1px solid rgba(0, 0, 0, 0.12)',
-      padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`
-    }
+      padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
+    },
   };
 });
 
@@ -74,7 +74,6 @@ function SQFormScrollableCard({
   SubHeaderComponent,
   title,
   validationSchema,
-  isHeaderDisabled = false
 }) {
   const hasSubHeader = Boolean(SubHeaderComponent);
 
@@ -94,9 +93,10 @@ function SQFormScrollableCard({
     {leading: true, trailing: false}
   );
 
-  const formattedTitle = React.useMemo(() => title.replace(/\s/g, '-'), [
-    title
-  ]);
+  const formattedTitle = React.useMemo(
+    () => title.replace(/\s/g, '-'),
+    [title]
+  );
 
   const [calculatedHeight, setCalculatedHeight] = React.useState(0);
 
@@ -109,8 +109,8 @@ function SQFormScrollableCard({
     const offsetBasedHeight = `calc(100vh - ${topOffset}px - 24px)`;
 
     const parentHeight = currentElement.parentElement.clientHeight;
-    const parentTopOffset = currentElement.parentElement.getBoundingClientRect()
-      .top;
+    const parentTopOffset =
+      currentElement.parentElement.getBoundingClientRect().top;
     const topDifferential = topOffset - parentTopOffset;
     const maxOffsetBasedHeight = `calc(${parentHeight}px - ${topDifferential}px)`;
 
@@ -134,7 +134,7 @@ function SQFormScrollableCard({
         validationSchema={validationYupSchema}
         validateOnMount={true}
       >
-        {_props => {
+        {(_props) => {
           return (
             <Form className={classes.form}>
               <Card
@@ -143,7 +143,7 @@ function SQFormScrollableCard({
                 square={true}
                 className={classes.card}
               >
-                {!isHeaderDisabled && (
+                {title && (
                   <CardHeader
                     title={title}
                     className={classes.cardHeader}
@@ -240,7 +240,7 @@ SQFormScrollableCard.propTypes = {
    * */
   validationSchema: PropTypes.object,
   //** Boolean used to determine if title/header is enabled or disabled */
-  isHeaderDisabled: PropTypes.bool
+  isHeaderDisabled: PropTypes.bool,
 };
 
 export default SQFormScrollableCard;


### PR DESCRIPTION
Recently we had done an enhancement that would allow the user to disable the rendering of a header based on a true/false boolean prop value.

However I realize now that we really didn't need a specific prop for this, rather we could simply check if we have a title set or not. 

Loom: https://www.loom.com/share/9563e54ab7c141b1b9c21fdfd2de4616