### PR TITLE
feat: 🎸 New component: SQFormMaskedReadOnlyField

### DIFF
--- a/src/components/SQForm/SQFormMaskedReadOnlyField.js
+++ b/src/components/SQForm/SQFormMaskedReadOnlyField.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import MaskedInput from 'react-text-mask';
+import SQFormReadOnlyField from './SQFormReadOnlyField';
+
+function TextFieldMask({inputRef, mask, ...rest}) {
+  return (
+    <MaskedInput
+      {...rest}
+      ref={ref => {
+        inputRef(ref ? ref.inputElement : null);
+      }}
+      mask={mask}
+      placeholderChar={'\u2000'}
+      showMask={false}
+    />
+  );
+}
+
+function SQFormMaskedReadOnlyField({
+  mask,
+  name,
+  label,
+  size = 'auto',
+  InputProps,
+  inputProps = {},
+  muiFieldProps = {}
+}) {
+  return (
+    <SQFormReadOnlyField
+      name={name}
+      label={label}
+      size={size}
+      InputProps={{
+        ...InputProps,
+        inputComponent: TextFieldMask
+      }}
+      inputProps={{
+        ...inputProps,
+        mask
+      }}
+      muiFieldProps={muiFieldProps}
+    />
+  );
+}
+
+SQFormMaskedReadOnlyField.propTypes = {
+  /** Valid mask array; custom or from utils/masks.js */
+  mask: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array,
+    PropTypes.func
+  ]),
+  /** Name of the field will be the Object key of the key/value pair form payload */
+  name: PropTypes.string.isRequired,
+  /** Descriptive label of the input */
+  label: PropTypes.string.isRequired,
+  /** Size of the input given full-width is 12. */
+  size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+  /** Props applied to the Input element */
+  InputProps: PropTypes.object,
+  /** Attributes applied to the `input` element */
+  inputProps: PropTypes.object,
+  /** Any valid prop for material ui text input child component - https://material-ui.com/api/text-field/#props */
+  muiFieldProps: PropTypes.object
+};
+
+export default SQFormMaskedReadOnlyField;

--- a/src/components/SQForm/SQFormReadOnlyField.js
+++ b/src/components/SQForm/SQFormReadOnlyField.js
@@ -5,7 +5,14 @@ import TextField from '@material-ui/core/TextField';
 import {useForm} from './useForm';
 import {toKebabCase} from '../../utils';
 
-function SQFormReadOnlyField({label, name, size = 'auto', muiFieldProps = {}}) {
+function SQFormReadOnlyField({
+  label,
+  name,
+  size = 'auto',
+  InputProps = {},
+  inputProps = {},
+  muiFieldProps = {}
+}) {
   const {
     formikField: {field}
   } = useForm({name, isRequired: false});
@@ -20,9 +27,11 @@ function SQFormReadOnlyField({label, name, size = 'auto', muiFieldProps = {}}) {
         fullWidth={true}
         InputLabelProps={{shrink: true}}
         InputProps={{
+          ...InputProps,
           readOnly: true,
           disableUnderline: true
         }}
+        inputProps={inputProps}
         style={{marginBottom: 21}}
         {...muiFieldProps}
       />
@@ -37,6 +46,10 @@ SQFormReadOnlyField.propTypes = {
   name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Size of the input given full-width is 12. */
   size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+  /** Props applied to the Input element */
+  InputProps: PropTypes.object,
+  /** Attributes applied to the `input` element */
+  inputProps: PropTypes.object,
   /** Any valid prop for material ui text input child component - https://material-ui.com/api/text-field/#props */
   muiFieldProps: PropTypes.object
 };

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ export {default as SQFormTextarea} from './components/SQForm/SQFormTextarea';
 export {default as SQFormTextField} from './components/SQForm/SQFormTextField';
 export {default as SQFormMultiSelect} from './components/SQForm/SQFormMultiSelect';
 export {default as SQFormMaskedTextField} from './components/SQForm/SQFormMaskedTextField';
+export {default as SQFormMaskedReadOnlyField} from './components/SQForm/SQFormMaskedReadOnlyField';
 export {default as SQFormHelperText} from './components/SQForm/SQFormHelperText';
 export {default as SQFormScrollableCard} from './components/SQFormScrollableCard';
 export {default as SQFormScrollableCardsMenuWrapper} from './components/SQFormScrollableCardsMenuWrapper';

--- a/stories/SQFormMaskedReadOnlyField.stories.js
+++ b/stories/SQFormMaskedReadOnlyField.stories.js
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import {
+  MASKS,
+  SQFormMaskedReadOnlyField as SQFormMaskedReadOnlyFieldComponent
+} from '../src';
+import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
+import {createDocsPage} from './utils/createDocsPage';
+
+export default {
+  title: 'Components/SQFormMaskedReadOnlyField',
+  component: SQFormMaskedReadOnlyFieldComponent,
+  argTypes: {
+    onBlur: {action: 'blurred', table: {disable: true}},
+    onChange: {action: 'changed', table: {disable: true}},
+    name: {table: {disable: true}}
+  },
+  parameters: {
+    docs: {
+      page: createDocsPage()
+    }
+  }
+};
+
+const defaultArgs = {
+  label: 'Masked Read Only Field',
+  name: 'maskedReadOnlyField'
+};
+
+const Template = args => {
+  const {schema, SQFormProps, exampleMasks, ...rest} = args;
+  return (
+    <SQFormStoryWrapper
+      initialValues={{[defaultArgs.name]: '8168675309'}}
+      validationSchema={schema}
+      showSubmit={false}
+      {...SQFormProps}
+    >
+      <SQFormMaskedReadOnlyFieldComponent
+        {...rest}
+        size={getSizeProp(args.size)}
+        mask={exampleMasks}
+      />
+    </SQFormStoryWrapper>
+  );
+};
+
+const getSizeProp = size => {
+  switch (size) {
+    case true:
+    case false:
+    case 'auto':
+      return size;
+    case undefined:
+      return 'auto';
+    default:
+      return Number(size);
+  }
+};
+
+export const Default = Template.bind({});
+Default.storyName = 'SQFormMaskedTextField';
+Default.args = defaultArgs;
+Default.argTypes = {
+  exampleMasks: {
+    name: 'Example masks',
+    options: Object.keys(MASKS),
+    mapping: MASKS,
+    control: {
+      type: 'select'
+    },
+    defaultValue: 'phone'
+  }
+};

--- a/stories/SQFormReadOnlyField.stories.js
+++ b/stories/SQFormReadOnlyField.stories.js
@@ -25,7 +25,10 @@ const defaultArgs = {
 
 const Template = ({initialValue = '', ...args}) => {
   return (
-    <SQFormStoryWrapper initialValues={{[defaultArgs.name]: initialValue}}>
+    <SQFormStoryWrapper
+      initialValues={{[defaultArgs.name]: initialValue}}
+      showSubmit={false}
+    >
       <SQFormReadOnlyFieldComponent
         {...args}
         size={args.size !== 'auto' ? Number(args.size) : args.size}


### PR DESCRIPTION
Created a new component SQFormMaskedReadOnlyField

It's a pretty common use case, it seems, to want to display masked data in a read only format. `isDisabled` on SQFormMaskedTextField changes the styling to be "disabled" which is no good and, as described in #444, there are hacky ways to do it but this seems like a good solution.

I created a new component instead of exposing something like `isReadOnly` on the original component to stay in line with how the vanilla `SQFormTextField` and `SQFormReadOnlyField` components are.

Also, checkout this 🔥  🔥  🔥 🔥  🔥 🔥  🔥 🔥  UI

![Screen Shot 2021-09-28 at 2 50 10 PM](https://user-images.githubusercontent.com/29528409/135156081-92d19e2b-ed86-4b4f-9d0d-b670acf67dd1.png)
closes #444 