### PR TITLE
chore: 🤖 Linter - Ignore docs directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+docs
 *.css
 *.json
 *.md


### PR DESCRIPTION
✅ Closes: #454

Linter no longer attempts to lint compiled JS files in the `/docs` directory