### PR TITLE
fix: 🐛 Change scrollbar to only Dialog body

### DIFF
--- a/src/components/SQFormDialog/SQFormDialogInner.js
+++ b/src/components/SQFormDialog/SQFormDialogInner.js
@@ -46,7 +46,7 @@ const useActionsStyles = makeStyles({
 });
 const useDialogContentStyles = makeStyles({
   root: {
-    overflowY: 'visible',
+    maxHeight: '75vh',
     padding: '20px'
   }
 });
@@ -94,6 +94,7 @@ function SQFormDialogInner({
   return (
     <>
       <Dialog
+        scroll="body"
         disableBackdropClick={disableBackdropClick}
         maxWidth={maxWidth}
         open={isOpen}


### PR DESCRIPTION
Changes scrollbar for SQFormDialog component to be just on the body of the modal, instead of the entire modal.

https://www.loom.com/share/660302d94c8d4fce8e446be1b3b6d3a4

✅ Closes: #465