### PR TITLE
fix: 🐛 No longer need to pass isRequired to form components

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,50 @@ For **BREAKING CHANGES** Type a brief description of the breaking change when as
 
 - `> npm install @selectquotelabs/sqform`
 
+## Breaking Changes
+
+### Version 6
+
+In SQForm v6, we no longer need to pass the `isRequired` prop to any form components. The components now derive whether or not they are a required field based on the Yup validation schema of the form.
+
+While removing this boilerplate is nice, this allows us to handle situations where a fields `required` attribute is conditional. We can fully rely on the validation schema rather than also creating a mechanism to make `isRequired` conditional and keeping the `isRequired` prop in sync with the validation schema.
+
+We ALWAYS want a required field to say `Required` in the fields helper text. We are no longer required to specify the `Required` text within our validation schemas as long as we follow the setup below in the consumer app. Otherwise, you'll still need to say for example: `foo: Yup.string().required('Required')`
+
+When updating the consuming applications version of SQForm to v6, please add this code to the root of the client:
+
+```
+// root of the consumer app such as index.js
+import {setLocale} from 'yup';
+
+setLocale({
+  mixed: {
+    required: 'Required',
+  },
+});
+```
+
+During this time, please search the project for validation schemas that use `array()`. If they are `required`.
+Please ensure `.required()` is the FIRST validation method in the chain.
+
+```
+// ✅ Example
+options: Yup.array()
+  .required()
+  .min(1, 'Please choose one option'),
+```
+
+```
+// ⛔️ Example
+options: Yup.array()
+  .min(1, 'Please choose one option')
+  .required(),
+```
+
+When upgrading the consumer application to SQForm v6, we should also cleanup any use of the `isRequired` prop. While this is optional in JavaScript projects, this is extra noise and a possible spot of confusion for future new developers. The `isRequired` prop does nothing in v6.
+
+For TypeScript, please remove the `isRequired` property from any TypeScript `types` and `interfaces`.
+
 ## Migration from SC+ Shared Components Library
 
 - `> npm install @selectquotelabs/sqform`

--- a/SQFormDocs/docs/introduction.mdx
+++ b/SQFormDocs/docs/introduction.mdx
@@ -58,8 +58,8 @@ The `onSubmit` function has two parameters. Values and Actions. [Formik onSubmit
  const initialValues = { firstName: '', lastName: ''}
 
 const validationSchema = {
-  firstName: Yup.string().required('Required'),
-  lastName: Yup.string().required('Required'),
+  firstName: Yup.string().required(),
+  lastName: Yup.string().required(),
 };
 
 function HelloForm() {

--- a/notes/SQFormMultiValue.md
+++ b/notes/SQFormMultiValue.md
@@ -44,9 +44,9 @@ In english this validation says "nameOfField's value must be an array of numbers
         return typeof value === 'number' ? Yup.number() : Yup.string();
       })
     )
+    // Ensures this field is filled before submission
+    .required(),
     // Minimum one selection required
     .min(1)
-    // Ensures this field is filled before submission
-    .required('Required'),
 }
 ```

--- a/src/components/SQForm/SQForm.js
+++ b/src/components/SQForm/SQForm.js
@@ -3,8 +3,14 @@ import PropTypes from 'prop-types';
 import Grid from '@material-ui/core/Grid';
 import {Formik, Form} from 'formik';
 import {useDebouncedCallback} from 'use-debounce';
-import * as Yup from 'yup';
+import {object as YupObject, setLocale} from 'yup';
 import {useInitialRequiredErrors} from '../../hooks/useInitialRequiredErrors';
+
+setLocale({
+  mixed: {
+    required: 'Required'
+  }
+});
 
 function SQForm({
   children,
@@ -17,7 +23,7 @@ function SQForm({
   const validationYupSchema = React.useMemo(() => {
     if (!validationSchema) return;
 
-    return Yup.object().shape(validationSchema);
+    return YupObject().shape(validationSchema);
   }, [validationSchema]);
 
   const initialErrors = useInitialRequiredErrors(

--- a/src/components/SQForm/SQFormAsyncAutocomplete.js
+++ b/src/components/SQForm/SQFormAsyncAutocomplete.js
@@ -85,7 +85,6 @@ const ListboxVirtualizedComponent = React.forwardRef(
 function SQFormAsyncAutocomplete({
   children,
   isDisabled = false,
-  isRequired = false,
   label,
   name,
   onBlur,
@@ -102,12 +101,9 @@ function SQFormAsyncAutocomplete({
   const {setFieldValue, setTouched, values} = useFormikContext();
   const [{value}] = useField(name);
   const {
-    fieldState: {isFieldError},
+    fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {HelperTextComponent}
-  } = useForm({
-    name,
-    isRequired
-  });
+  } = useForm({name});
 
   const initialValue = React.useMemo(() => {
     const optionInitialValue = children.find(option => {
@@ -215,7 +211,7 @@ function SQFormAsyncAutocomplete({
               name={name}
               label={label}
               helperText={!isDisabled && HelperTextComponent}
-              required={isRequired}
+              required={isFieldRequired}
             />
           );
         }}
@@ -241,8 +237,6 @@ SQFormAsyncAutocomplete.propTypes = {
   handleAsyncInputChange: PropTypes.func.isRequired,
   /** Disabled property to disable the input if true */
   isDisabled: PropTypes.bool,
-  /** Required property used to highlight input and label if not fulfilled */
-  isRequired: PropTypes.bool,
   /** Whether the component is loading */
   loading: PropTypes.bool,
   /** Label text */

--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -198,7 +198,6 @@ const useAutocompleteStyles = makeStyles({
 function SQFormAutocomplete({
   children,
   isDisabled = false,
-  isRequired = false,
   displayEmpty = false,
   label,
   name,
@@ -217,12 +216,9 @@ function SQFormAutocomplete({
   const {setFieldValue, setTouched, values, touched} = useFormikContext();
   const [{value}] = useField(name);
   const {
-    fieldState: {isFieldError},
+    fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {HelperTextComponent}
-  } = useForm({
-    name,
-    isRequired
-  });
+  } = useForm({name});
 
   const initialValue = getInitialValue(children, value, displayEmpty);
 
@@ -313,7 +309,7 @@ function SQFormAutocomplete({
               name={name}
               label={label}
               helperText={!isDisabled && HelperTextComponent}
-              required={isRequired}
+              required={isFieldRequired}
             />
           );
         }}
@@ -338,8 +334,6 @@ SQFormAutocomplete.propTypes = {
   ),
   /** Disabled property to disable the input if true */
   isDisabled: PropTypes.bool,
-  /** Required property used to highlight input and label if not fulfilled */
-  isRequired: PropTypes.bool,
   /** Whether to display empty option */
   displayEmpty: PropTypes.bool,
   /** Label text */

--- a/src/components/SQForm/SQFormCheckbox.js
+++ b/src/components/SQForm/SQFormCheckbox.js
@@ -17,11 +17,7 @@ function SQFormCheckbox({
   const {
     formikField: {field},
     fieldHelpers: {handleChange}
-  } = useForm({
-    name,
-    isRequired: false,
-    onChange
-  });
+  } = useForm({name, onChange});
 
   return (
     <Grid item sm={size}>

--- a/src/components/SQForm/SQFormCheckboxGroup.js
+++ b/src/components/SQForm/SQFormCheckboxGroup.js
@@ -13,7 +13,6 @@ import {useForm} from './useForm';
 function SQFormCheckboxGroup({
   name,
   groupLabel,
-  isRequired = false,
   onChange,
   shouldDisplayInRow = false,
   shouldUseSelectAll = false,
@@ -21,13 +20,9 @@ function SQFormCheckboxGroup({
   children
 }) {
   const {
-    fieldState: {isFieldError},
+    fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {handleChange, handleBlur, HelperTextComponent}
-  } = useForm({
-    name,
-    isRequired,
-    onChange
-  });
+  } = useForm({name, onChange});
 
   const {setFieldValue} = useFormikContext();
 
@@ -84,7 +79,7 @@ function SQFormCheckboxGroup({
     <Grid item sm={size}>
       <FormControl
         component="fieldset"
-        required={isRequired}
+        required={isFieldRequired}
         error={isFieldError}
         onBlur={handleBlur}
       >
@@ -111,8 +106,6 @@ SQFormCheckboxGroup.propTypes = {
   name: PropTypes.string.isRequired,
   /** Label to display above the group */
   groupLabel: PropTypes.string.isRequired,
-  /** Whether this a selection in this group is required */
-  isRequired: PropTypes.bool,
   /** Function to call on value change */
   onChange: PropTypes.func,
   /** Whether to display the group in a row */

--- a/src/components/SQForm/SQFormCheckboxGroupItem.js
+++ b/src/components/SQForm/SQFormCheckboxGroupItem.js
@@ -26,11 +26,7 @@ function SQFormCheckboxGroupItem({
   const {
     formikField: {field},
     fieldHelpers: {handleChange}
-  } = useForm({
-    name: groupName,
-    isRequired: false,
-    onChange
-  });
+  } = useForm({name: groupName, onChange});
 
   const classes = useStyles();
 

--- a/src/components/SQForm/SQFormDatePicker.js
+++ b/src/components/SQForm/SQFormDatePicker.js
@@ -21,7 +21,6 @@ function SQFormDatePicker({
   label,
   size = 'auto',
   isDisabled = false,
-  isRequired = false,
   placeholder = '',
   onBlur,
   onChange,
@@ -32,11 +31,10 @@ function SQFormDatePicker({
 }) {
   const {
     formikField: {field, helpers},
-    fieldState: {isFieldError},
+    fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {handleBlur, HelperTextComponent}
   } = useForm({
     name,
-    isRequired,
     onBlur,
     onChange
   });
@@ -86,7 +84,7 @@ function SQFormDatePicker({
                 helperText={!isDisabled && HelperTextComponent}
                 placeholder={placeholder}
                 onBlur={handleBlur}
-                required={isRequired}
+                required={isFieldRequired}
                 onClick={
                   isCalendarOnly && !isDisabled
                     ? toggleCalendar
@@ -106,8 +104,6 @@ function SQFormDatePicker({
 SQFormDatePicker.propTypes = {
   /** Disabled property to disable the input if true */
   isDisabled: PropTypes.bool,
-  /** Required property used to highlight input and label if not fulfilled */
-  isRequired: PropTypes.bool,
   /** Descriptive label of the input */
   label: PropTypes.string.isRequired,
   /** Name of the field will be the Object key of the key/value pair form payload */

--- a/src/components/SQForm/SQFormDatePickerWithCalendarInputOnly.js
+++ b/src/components/SQForm/SQFormDatePickerWithCalendarInputOnly.js
@@ -4,6 +4,7 @@ import ClearIcon from '@material-ui/icons/HighlightOff';
 import {useFormikContext} from 'formik';
 import {IconButton, makeStyles} from '@material-ui/core';
 import SQFormDatePicker from './SQFormDatePicker';
+import {useForm} from './useForm';
 
 const useClearButtonStyles = makeStyles({
   root: {
@@ -29,13 +30,20 @@ function SQFormDatePickerWithCalendarInputOnly({
   label,
   size = 'auto',
   isDisabled = false,
-  isRequired = false,
   placeholder = '',
   onBlur,
   onChange,
   setDisabledDate,
   muiFieldProps = {}
 }) {
+  const {
+    fieldState: {isFieldRequired},
+    fieldHelpers: {handleBlur, handleChange}
+  } = useForm({
+    name,
+    onBlur,
+    onChange
+  });
   const clearButtonClasses = useClearButtonStyles();
   const calendarButtonClasses = useCalendarButtonStyles();
   const {values, setFieldValue} = useFormikContext();
@@ -50,10 +58,10 @@ function SQFormDatePickerWithCalendarInputOnly({
       label={label}
       size={size}
       isDisabled={isDisabled}
-      isRequired={isRequired}
+      isRequired={isFieldRequired}
       placeholder={placeholder}
-      onBlur={onBlur}
-      onChange={onChange}
+      onBlur={handleBlur}
+      onChange={handleChange}
       setDisabledDate={setDisabledDate}
       isCalendarOnly={true}
       muiFieldProps={{
@@ -85,8 +93,6 @@ function SQFormDatePickerWithCalendarInputOnly({
 SQFormDatePickerWithCalendarInputOnly.propTypes = {
   /** Disabled property to disable the input if true */
   isDisabled: PropTypes.bool,
-  /** Required property used to highlight input and label if not fulfilled */
-  isRequired: PropTypes.bool,
   /** Descriptive label of the input */
   label: PropTypes.string.isRequired,
   /** Name of the field will be the Object key of the key/value pair form payload */

--- a/src/components/SQForm/SQFormDateTimePicker.js
+++ b/src/components/SQForm/SQFormDateTimePicker.js
@@ -21,7 +21,6 @@ function SQFormDateTimePicker({
   label,
   size = 'auto',
   isDisabled = false,
-  isRequired = false,
   placeholder = '',
   onBlur,
   onChange,
@@ -29,11 +28,10 @@ function SQFormDateTimePicker({
 }) {
   const {
     formikField: {field, helpers},
-    fieldState: {isFieldError},
+    fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {handleBlur, HelperTextComponent}
   } = useForm({
     name,
-    isRequired,
     onBlur,
     onChange
   });
@@ -83,7 +81,7 @@ function SQFormDateTimePicker({
                 placeholder={placeholder}
                 onBlur={handleBlur}
                 onClick={handleClickAway}
-                required={isRequired}
+                required={isFieldRequired}
                 classes={classes}
               />
             );
@@ -98,8 +96,6 @@ function SQFormDateTimePicker({
 SQFormDateTimePicker.propTypes = {
   /** Disabled property to disable the input if true */
   isDisabled: PropTypes.bool,
-  /** Required property used to highlight input and label if not fulfilled */
-  isRequired: PropTypes.bool,
   /** Descriptive label of the input */
   label: PropTypes.string.isRequired,
   /** Name of the field will be the Object key of the key/value pair form payload */

--- a/src/components/SQForm/SQFormDropdown.js
+++ b/src/components/SQForm/SQFormDropdown.js
@@ -32,7 +32,6 @@ function SQFormDropdown({
   children,
   displayEmpty = false,
   isDisabled = false,
-  isRequired = false,
   label,
   name,
   onBlur,
@@ -44,11 +43,10 @@ function SQFormDropdown({
 
   const {
     formikField: {field},
-    fieldState: {isFieldError},
+    fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {handleBlur, handleChange, HelperTextComponent}
   } = useForm({
     name,
-    isRequired,
     onBlur,
     onChange
   });
@@ -97,7 +95,7 @@ function SQFormDropdown({
     <Grid item sm={size}>
       <FormControl
         error={isFieldError}
-        required={isRequired}
+        required={isFieldRequired}
         disabled={isDisabled}
         fullWidth={true}
       >
@@ -150,8 +148,6 @@ SQFormDropdown.propTypes = {
   displayEmpty: PropTypes.bool,
   /** Disabled property to disable the input if true */
   isDisabled: PropTypes.bool,
-  /** Required property used to highlight input and label if not fulfilled */
-  isRequired: PropTypes.bool,
   /** Label text */
   label: PropTypes.string.isRequired,
   /** Name identifier of the input field */

--- a/src/components/SQForm/SQFormInclusionListItem.js
+++ b/src/components/SQForm/SQFormInclusionListItem.js
@@ -18,7 +18,6 @@ function SQFormInclusionListItem({
     fieldHelpers: {handleChange}
   } = useForm({
     name,
-    isRequired: false,
     onChange
   });
 

--- a/src/components/SQForm/SQFormMaskedTextField.js
+++ b/src/components/SQForm/SQFormMaskedTextField.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import MaskedInput from 'react-text-mask';
 import {useFormikContext} from 'formik';
 import SQFormTextField from './SQFormTextField';
+import {useForm} from './useForm';
 
 function TextFieldMask({inputRef, mask, ...rest}) {
   return (
@@ -23,7 +24,6 @@ function SQFormMaskedTextField({
   name,
   label,
   isDisabled = false,
-  isRequired = false,
   placeholder,
   size = 'auto',
   onBlur,
@@ -36,6 +36,14 @@ function SQFormMaskedTextField({
   muiFieldProps = {},
   stripNonNumeric = false
 }) {
+  const {
+    fieldState: {isFieldRequired},
+    fieldHelpers: {handleBlur, handleChange}
+  } = useForm({
+    name,
+    onBlur,
+    onChange
+  });
   const {setFieldValue} = useFormikContext();
 
   const handleChangeStripNonNumeric = event => {
@@ -48,11 +56,11 @@ function SQFormMaskedTextField({
       name={name}
       label={label}
       isDisabled={isDisabled}
-      isRequired={isRequired}
+      isRequired={isFieldRequired}
       placeholder={placeholder}
       size={size}
-      onBlur={onBlur}
-      onChange={stripNonNumeric ? handleChangeStripNonNumeric : onChange}
+      onBlur={handleBlur}
+      onChange={stripNonNumeric ? handleChangeStripNonNumeric : handleChange}
       startAdornment={startAdornment}
       endAdornment={endAdornment}
       type={type}
@@ -84,8 +92,6 @@ SQFormMaskedTextField.propTypes = {
   placeholder: PropTypes.string,
   /** Disabled property to disable the input if true */
   isDisabled: PropTypes.bool,
-  /** Required property used to highlight input and label if not fulfilled */
-  isRequired: PropTypes.bool,
   /** Size of the input given full-width is 12. */
   size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
   /** Custom onBlur event callback */

--- a/src/components/SQForm/SQFormMultiSelect.js
+++ b/src/components/SQForm/SQFormMultiSelect.js
@@ -74,7 +74,6 @@ const useStyles = makeStyles({
 function SQFormMultiSelect({
   children,
   isDisabled = false,
-  isRequired = false,
   label,
   name,
   onChange,
@@ -91,12 +90,9 @@ function SQFormMultiSelect({
   const [toolTipEnabled, setToolTipEnabled] = React.useState(true);
   const {
     formikField: {field},
-    fieldState: {isFieldError},
+    fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {handleBlur, HelperTextComponent}
-  } = useForm({
-    name,
-    isRequired
-  });
+  } = useForm({name});
 
   React.useEffect(() => {
     if (!children) {
@@ -175,7 +171,7 @@ function SQFormMultiSelect({
       <FormControl
         error={isFieldError}
         disabled={isDisabled}
-        required={isRequired}
+        required={isFieldRequired}
         fullWidth={true}
       >
         <InputLabel shrink={true} id={labelID}>
@@ -246,8 +242,6 @@ SQFormMultiSelect.propTypes = {
   ),
   /** Disabled property to disable the input if true */
   isDisabled: PropTypes.bool,
-  /** Required property used to highlight input and label if not fulfilled */
-  isRequired: PropTypes.bool,
   /** Label text */
   label: PropTypes.string.isRequired,
   /** Custom onChange event callback */

--- a/src/components/SQForm/SQFormMultiValue.js
+++ b/src/components/SQForm/SQFormMultiValue.js
@@ -90,7 +90,6 @@ function SQFormMultiValue({
   name,
   label,
   size = 'auto',
-  isRequired = false,
   isDisabled = false,
   onInputChange,
   onChange,
@@ -103,10 +102,7 @@ function SQFormMultiValue({
   const {
     fieldState: {isFieldError},
     fieldHelpers: {HelperTextComponent}
-  } = useForm({
-    name,
-    isRequired
-  });
+  } = useForm({name});
 
   const [inputValue, setInputValue] = React.useState('');
   const [customOptions, setCustomOptions] = React.useState([]);
@@ -310,8 +306,6 @@ SQFormMultiValue.propTypes = {
   label: PropTypes.string.isRequired,
   /** Size of the input given full-width is 12. */
   size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-  /** Whether the field is required */
-  isRequired: PropTypes.bool,
   /** Whether the field is disabled */
   isDisabled: PropTypes.bool,
   /** Custom handler for input value change */

--- a/src/components/SQForm/SQFormRadioButtonGroup.js
+++ b/src/components/SQForm/SQFormRadioButtonGroup.js
@@ -11,21 +11,16 @@ import {useForm} from './useForm';
 function SQFormRadioButtonGroup({
   name,
   onChange,
-  isRequired = false,
   shouldDisplayInRow = false,
   size = 'auto',
   groupLabel,
   children
 }) {
   const {
-    fieldState: {isFieldError},
+    fieldState: {isFieldError, isFieldRequired},
     formikField: {field},
     fieldHelpers: {handleChange, handleBlur, HelperTextComponent}
-  } = useForm({
-    name,
-    isRequired,
-    onChange
-  });
+  } = useForm({name, onChange});
 
   const childrenToRadioGroupItems = () => {
     return children.map(radioOption => {
@@ -47,7 +42,7 @@ function SQFormRadioButtonGroup({
     <Grid item sm={size}>
       <FormControl
         component="fieldset"
-        required={isRequired}
+        required={isFieldRequired}
         error={isFieldError}
         onBlur={handleBlur}
       >
@@ -80,8 +75,6 @@ SQFormRadioButtonGroup.propTypes = {
   name: PropTypes.string.isRequired,
   /** Function to call on value change */
   onChange: PropTypes.func,
-  /** Whether this radio selection is required */
-  isRequired: PropTypes.bool,
   /** Whether to display group in row */
   shouldDisplayInRow: PropTypes.bool,
   /** Size of the input given full-width is 12. */

--- a/src/components/SQForm/SQFormReadOnlyField.js
+++ b/src/components/SQForm/SQFormReadOnlyField.js
@@ -15,7 +15,7 @@ function SQFormReadOnlyField({
 }) {
   const {
     formikField: {field}
-  } = useForm({name, isRequired: false});
+  } = useForm({name});
 
   return (
     <Grid item sm={size}>

--- a/src/components/SQForm/SQFormTextField.js
+++ b/src/components/SQForm/SQFormTextField.js
@@ -11,7 +11,6 @@ function SQFormTextField({
   name,
   label,
   isDisabled = false,
-  isRequired = false,
   placeholder = '- -',
   size = 'auto',
   onBlur,
@@ -26,7 +25,7 @@ function SQFormTextField({
 }) {
   const {
     formikField: {field},
-    fieldState: {isFieldError},
+    fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {
       handleBlur,
       handleChange: handleChangeHelper,
@@ -34,7 +33,6 @@ function SQFormTextField({
     }
   } = useForm({
     name,
-    isRequired,
     onBlur,
     onChange
   });
@@ -91,7 +89,7 @@ function SQFormTextField({
         placeholder={placeholder}
         onChange={handleChange}
         onBlur={handleBlur}
-        required={isRequired}
+        required={isFieldRequired}
         value={field.value}
         {...muiFieldProps}
       />
@@ -108,8 +106,6 @@ SQFormTextField.propTypes = {
   placeholder: PropTypes.string,
   /** Disabled property to disable the input if true */
   isDisabled: PropTypes.bool,
-  /** Required property used to highlight input and label if not fulfilled */
-  isRequired: PropTypes.bool,
   /** Size of the input given full-width is 12. */
   size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
   /** Custom onBlur event callback */

--- a/src/components/SQForm/SQFormTextarea.js
+++ b/src/components/SQForm/SQFormTextarea.js
@@ -11,7 +11,6 @@ function SQFormTextarea({
   name,
   label,
   isDisabled = false,
-  isRequired = false,
   placeholder = '',
   size = 'auto',
   onBlur,
@@ -24,7 +23,7 @@ function SQFormTextarea({
 }) {
   const {values} = useFormikContext();
   const {
-    fieldState: {isFieldError},
+    fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {
       handleBlur,
       handleChange: handleChangeHelper,
@@ -32,7 +31,6 @@ function SQFormTextarea({
     }
   } = useForm({
     name,
-    isRequired,
     onBlur,
     onChange
   });
@@ -73,7 +71,7 @@ function SQFormTextarea({
         placeholder={placeholder}
         onChange={handleChange}
         onBlur={handleBlur}
-        required={isRequired}
+        required={isFieldRequired}
         rows={rows}
         rowsMax={rowsMax}
         variant="outlined"
@@ -97,8 +95,6 @@ SQFormTextarea.propTypes = {
   placeholder: PropTypes.string,
   /** Disabled property to disable the input if true */
   isDisabled: PropTypes.bool,
-  /** Required property used to highlight input and label if not fulfilled */
-  isRequired: PropTypes.bool,
   /** Size of the input given full-width is 12. */
   size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
   /** Custom onBlur event callback */

--- a/src/components/SQForm/useForm.js
+++ b/src/components/SQForm/useForm.js
@@ -6,12 +6,9 @@ import VerifiedIcon from '@material-ui/icons/VerifiedUser';
 
 const SPACE_STYLE = {marginRight: '0.3333rem'};
 
-function _handleError(name, isRequired) {
+function _handleError(name) {
   if (typeof name !== 'string') {
     throw new Error('Name is a required param and must be a String!');
-  }
-  if (typeof isRequired !== 'boolean') {
-    throw new Error('isRequired is a required param and must be a Boolean!');
   }
 }
 
@@ -33,8 +30,8 @@ function _getHasValue(meta) {
   return !!fieldValue;
 }
 
-export function useForm({name, isRequired, onBlur, onChange}) {
-  _handleError(name, isRequired);
+export function useForm({name, onBlur, onChange}) {
+  _handleError(name);
 
   const [field, meta, helpers] = useField(name);
   const errorMessage = getIn(meta, 'error');
@@ -42,6 +39,7 @@ export function useForm({name, isRequired, onBlur, onChange}) {
   const isDirty = !isEqual(meta.initialValue, meta.value);
   const hasValue = _getHasValue(meta);
   const isError = !!errorMessage;
+  const isRequired = errorMessage?.toLowerCase() === 'required';
 
   const getFieldStatus = () => {
     if (isRequired && !hasValue && !isDirty && !isTouched) {

--- a/stories/SQForm.stories.js
+++ b/stories/SQForm.stories.js
@@ -237,28 +237,28 @@ export const BasicForm = () => {
 
 export const FormWithValidation = () => {
   const validationSchema = {
-    firstName: Yup.string().required('Required'),
-    lastName: Yup.string().required('Required'),
+    firstName: Yup.string().required(),
+    lastName: Yup.string().required(),
     city: Yup.string(),
     age: Yup.number()
       .min(1, 'Age 1-65')
       .max(65, 'Age 1-65')
-      .required('Required'),
-    state: Yup.string().required('Required'),
-    tenThousandOptions: Yup.string().required('Required'),
-    preferredPet: Yup.string().required('Required'),
+      .required(),
+    state: Yup.string().required(),
+    tenThousandOptions: Yup.string().required(),
+    preferredPet: Yup.string().required(),
     warrantyOptions: Yup.array()
-      .min(1, 'One option required')
-      .required('Required'),
-    note: Yup.string().required('Required'),
+      .required()
+      .min(1, 'One option required'),
+    note: Yup.string().required(),
     favoriteColors: Yup.array()
       .of(
         Yup.lazy(value => {
           return typeof value === 'number' ? Yup.number() : Yup.string();
         })
       )
+      .required()
       .min(1)
-      .required('Required')
   };
 
   return (
@@ -272,52 +272,26 @@ export const FormWithValidation = () => {
           name="firstName"
           label="First name"
           size={6}
-          isRequired={true}
           maxCharacters={10}
         />
-        <SQFormTextField
-          name="lastName"
-          label="Last name"
-          size={6}
-          isRequired={true}
-        />
+        <SQFormTextField name="lastName" label="Last name" size={6} />
         <SQFormTextField name="city" label="City" size={3} />
         <SQFormAutocomplete
           name="tenThousandOptions"
           label="Ten Thousand Options"
           size={6}
-          isRequired={true}
         >
           {MOCK_AUTOCOMPLETE_OPTIONS}
         </SQFormAutocomplete>
-        <SQFormDropdown
-          name="state"
-          label="State"
-          isRequired={true}
-          displayEmpty={true}
-          size={5}
-        >
+        <SQFormDropdown name="state" label="State" displayEmpty={true} size={5}>
           {MOCK_STATE_OPTIONS}
         </SQFormDropdown>
-        <SQFormTextField
-          name="age"
-          label="Age"
-          type="number"
-          size={2}
-          isRequired={true}
-        />
-        <SQFormTextarea
-          name="note"
-          label="Note"
-          size={5}
-          isRequired={true}
-          maxCharacters={100}
-        />
+        <SQFormTextField name="age" label="Age" type="number" size={2} />
+        <SQFormTextarea name="note" label="Note" size={5} maxCharacters={100} />
         <SQFormRadioButtonGroup
           name="preferredPet"
           groupLabel="Cat or Dog?"
           shouldDisplayInRow={true}
-          isRequired={true}
         >
           {RADIO_GROUP_OPTIONS}
         </SQFormRadioButtonGroup>
@@ -325,7 +299,6 @@ export const FormWithValidation = () => {
           name="warrantyOptions"
           groupLabel="Warranty Options"
           shouldDisplayInRow={true}
-          isRequired={true}
         >
           {CHECKBOX_GROUP_OPTIONS}
         </SQFormCheckboxGroup>
@@ -333,7 +306,6 @@ export const FormWithValidation = () => {
           name="favoriteColors"
           label="Your Favorite Colors"
           size={4}
-          isRequired={true}
         >
           {MOCK_MULTI_VALUE_OPTIONS}
         </SQFormMultiValue>
@@ -489,7 +461,7 @@ export const formWithInclusionlist = () => {
 
 export const basicFormWithMultiSelect = () => {
   const validationSchema = {
-    friends: Yup.string().required('Required')
+    friends: Yup.string().required()
   };
 
   return (
@@ -508,7 +480,6 @@ export const basicFormWithMultiSelect = () => {
           name="friends"
           label="Friends"
           size={5}
-          isRequired={true}
           onChange={action('Friends selected')}
           useSelectAll={boolean('Use Select All', true)}
         >
@@ -525,14 +496,14 @@ export const basicFormWithMultiSelect = () => {
 export const basicFormWithMaskedFields = () => {
   const validationSchema = {
     phone: Yup.string()
-      .required('Required')
+      .required()
       .transform(value => value.replace(/[^\d]/g, ''))
       .min(10, 'Phone number must be 10 digits'),
     zip: Yup.string()
-      .required('Required')
+      .required()
       .transform(value => value.replace(/[^\d]/g, ''))
       .min(5, 'Zip code must be 5 digits'),
-    currency: Yup.string().required('Required')
+    currency: Yup.string().required()
   };
 
   return (
@@ -552,21 +523,18 @@ export const basicFormWithMaskedFields = () => {
           label="Phone"
           size={4}
           mask={MASKS.phone}
-          isRequired={true}
         />
         <SQFormMaskedTextField
           name="zip"
           label="Zip Code"
           size={4}
           mask={MASKS.zip}
-          isRequired={true}
         />
         <SQFormMaskedTextField
           name="currency"
           label="Currency"
           size={4}
           mask={MASKS.currency}
-          isRequired={true}
         />
         <SQFormMaskedTextField
           name="percent"
@@ -719,7 +687,7 @@ export const basicFormWithCustomOnChange = () => {
 
 export const applyAnAction = () => {
   const validationSchema = {
-    actions: Yup.string().required('Required')
+    actions: Yup.string().required()
   };
 
   return (
@@ -738,7 +706,6 @@ export const applyAnAction = () => {
           name="actions"
           label="Actions with a default value"
           size={5}
-          isRequired={true}
           isDisabled={boolean('Disable autocomplete', true)}
         >
           {ACTIONS_AUTOCOMPLETE_OPTIONS}
@@ -765,25 +732,22 @@ export const SQFormCheckboxGroupExample = () => {
     selectAll: false
   };
 
-  const isGroupRequired = boolean('Is group required', false);
-
   const validationSchema = {
     warrantyOptions: Yup.array()
       .min(1, 'Must select at least 1 option')
-      .required('Required')
+      .required()
   };
 
   return (
     <Card raised style={{padding: '16px', minWidth: '250px'}}>
       <SQForm
         initialValues={initialValues}
-        validationSchema={isGroupRequired ? validationSchema : {}}
+        validationSchema={validationSchema}
         onSubmit={handleSubmit}
       >
         <SQFormCheckboxGroup
           name="warrantyOptions"
           groupLabel="Warranty Options"
-          isRequired={isGroupRequired}
           shouldDisplayInRow={boolean('Should display in row', false)}
           shouldUseSelectAll={boolean('Should use select all', false)}
         >

--- a/stories/SQFormAsyncAutocomplete.stories.js
+++ b/stories/SQFormAsyncAutocomplete.stories.js
@@ -80,9 +80,8 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  isRequired: true,
   schema: {
-    [defaultArgs.name]: Yup.string().required('Required')
+    [defaultArgs.name]: Yup.string().required()
   }
 };
 WithValidation.parameters = {

--- a/stories/SQFormAutocomplete.stories.js
+++ b/stories/SQFormAutocomplete.stories.js
@@ -75,9 +75,8 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  isRequired: true,
   schema: {
-    [defaultArgs.name]: Yup.string().required('Required')
+    [defaultArgs.name]: Yup.string().required()
   }
 };
 WithValidation.parameters = {

--- a/stories/SQFormCheckboxGroup.stories.js
+++ b/stories/SQFormCheckboxGroup.stories.js
@@ -63,9 +63,8 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  isRequired: true,
   schema: {
-    [defaultArgs.name]: Yup.string().required('Required')
+    [defaultArgs.name]: Yup.string().required()
   }
 };
 WithValidation.parameters = {

--- a/stories/SQFormDialog.stories.js
+++ b/stories/SQFormDialog.stories.js
@@ -41,11 +41,7 @@ const Template = args => {
       </h1>
 
       <SQFormDialog {...args}>
-        <SQFormTextField
-          name="hello"
-          label="Hello"
-          isRequired={Boolean(args.validationSchema)}
-        />
+        <SQFormTextField name="hello" label="Hello" />
       </SQFormDialog>
     </>
   );
@@ -59,7 +55,7 @@ WithValidation.args = {
   ...defaultArgs,
   title: 'With Validation',
   validationSchema: {
-    hello: Yup.string().required('Required')
+    hello: Yup.string().required()
   }
 };
 

--- a/stories/SQFormDialogStepper.stories.js
+++ b/stories/SQFormDialogStepper.stories.js
@@ -105,22 +105,12 @@ export const WithValidation = args => {
         <SQFormDialogStep
           label="Personal Data"
           validationSchema={{
-            firstName: Yup.string().required('Required'),
-            lastName: Yup.string().required('Required')
+            firstName: Yup.string().required(),
+            lastName: Yup.string().required()
           }}
         >
-          <SQFormTextField
-            fullWidth
-            name="firstName"
-            label="First Name"
-            isRequired={true}
-          />
-          <SQFormTextField
-            fullWidth
-            name="lastName"
-            label="Last Name"
-            isRequired={true}
-          />
+          <SQFormTextField fullWidth name="firstName" label="First Name" />
+          <SQFormTextField fullWidth name="lastName" label="Last Name" />
         </SQFormDialogStep>
         <SQFormDialogStep
           label="Account Info"
@@ -128,7 +118,7 @@ export const WithValidation = args => {
             accountID: Yup.mixed().when('newPatient', {
               is: value => value === 'yes',
               then: Yup.number()
-                .required('Required for new account')
+                .required()
                 .min(100, 'Required for new account')
             })
           }}

--- a/stories/SQFormDropdown.stories.js
+++ b/stories/SQFormDropdown.stories.js
@@ -50,7 +50,7 @@ const booleanValueArgs = {
   label: 'Opt in?',
   name: 'isOptIn',
   children: YES_NO_OPTIONS,
-  schema: {isOptIn: Yup.bool().required('Required')},
+  schema: {isOptIn: Yup.bool().required()},
   SQFormProps: {
     initialValues: {isOptIn: false}
   }

--- a/stories/SQFormGuidedWorkflow.stories.js
+++ b/stories/SQFormGuidedWorkflow.stories.js
@@ -59,7 +59,7 @@ const Template = () => {
           }
         },
         validationSchema: {
-          outcome: Yup.string().required('Required'),
+          outcome: Yup.string().required(),
           notes: Yup.string()
         }
       },
@@ -70,7 +70,7 @@ const Template = () => {
       outcomeProps: {
         FormElements: (
           <>
-            <SQFormDropdown name="outcome" label="Outcome" isRequired={true}>
+            <SQFormDropdown name="outcome" label="Outcome">
               {outcomeDropdownOptions}
             </SQFormDropdown>
             <SQFormTextarea name="notes" label="Notes" />
@@ -97,7 +97,7 @@ const Template = () => {
           console.log(context);
         },
         validationSchema: {
-          outcome: Yup.string().required('Required'),
+          outcome: Yup.string().required(),
           notes: Yup.string()
         }
       },
@@ -109,7 +109,7 @@ const Template = () => {
       outcomeProps: {
         FormElements: (
           <>
-            <SQFormDropdown name="outcome" label="Outcome" isRequired={true}>
+            <SQFormDropdown name="outcome" label="Outcome">
               {outcomeDropdownOptions}
             </SQFormDropdown>
             <SQFormTextarea name="notes" label="Notes" />
@@ -144,7 +144,7 @@ const Template = () => {
           console.log(context);
         },
         validationSchema: {
-          outcome: Yup.string().required('Required'),
+          outcome: Yup.string().required(),
           notes: Yup.string()
         }
       },
@@ -157,7 +157,7 @@ const Template = () => {
       outcomeProps: {
         FormElements: (
           <>
-            <SQFormDropdown name="outcome" label="Outcome" isRequired={true}>
+            <SQFormDropdown name="outcome" label="Outcome">
               {outcomeDropdownOptions}
             </SQFormDropdown>
             <SQFormTextarea name="notes" label="Notes" />
@@ -206,7 +206,7 @@ const TestTemplate = args => {
           console.log(JSON.stringify(values));
         },
         validationSchema: {
-          firstText: Yup.string().required('Required'),
+          firstText: Yup.string().required(),
           secondText: Yup.string()
         }
       },

--- a/stories/SQFormMultiSelect.stories.js
+++ b/stories/SQFormMultiSelect.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as Yup from 'yup';
 
 import {SQFormMultiSelect as SQFormMultiSelectComponent} from '../src';
 import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
@@ -47,12 +48,13 @@ const defaultArgs = {
   children: MOCK_FRIENDS_OPTIONS
 };
 
-export const SQFormMultiSelect = args => {
-  const {SQFormProps, ...rest} = args;
+export const Template = args => {
+  const {SQFormProps, validationSchema, ...rest} = args;
   return (
     <div style={{minWidth: 250}}>
       <SQFormStoryWrapper
         initialValues={{[defaultArgs.name]: []}}
+        validationSchema={validationSchema}
         {...SQFormProps}
       >
         <SQFormMultiSelectComponent
@@ -65,8 +67,21 @@ export const SQFormMultiSelect = args => {
     </div>
   );
 };
-SQFormMultiSelect.storyName = 'SQFormMultiSelect';
+
+export const SQFormMultiSelect = Template.bind({});
 SQFormMultiSelect.args = defaultArgs;
+
+export const WithValidation = Template.bind({});
+WithValidation.args = {
+  validationSchema: {
+    friends: Yup.array()
+      .required()
+      .min(1)
+  },
+  SQFormProps: {
+    initialValues: {friends: []}
+  }
+};
 
 function random(length) {
   const characters =

--- a/stories/SQFormMultiValue.stories.js
+++ b/stories/SQFormMultiValue.stories.js
@@ -79,7 +79,6 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  isRequired: true,
   validationSchema: {
     favoriteColors: Yup.array()
       .of(
@@ -87,8 +86,8 @@ WithValidation.args = {
           return typeof value === 'number' ? Yup.number() : Yup.string();
         })
       )
+      .required()
       .min(1)
-      .required('Required')
   },
   SQFormProps: {
     initialValues: {favoriteColors: []}

--- a/stories/SQFormRadioButtonGroup.stories.js
+++ b/stories/SQFormRadioButtonGroup.stories.js
@@ -61,9 +61,8 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  isRequired: true,
   schema: {
-    [defaultArgs.name]: Yup.string().required('Required')
+    [defaultArgs.name]: Yup.string().required()
   }
 };
 WithValidation.parameters = {

--- a/stories/SQFormScrollableCard.stories.js
+++ b/stories/SQFormScrollableCard.stories.js
@@ -26,7 +26,7 @@ const defaultArgs = {
     alignItems: 'center'
   },
   onSubmit: () => {},
-  validationSchema: {hello: Yup.string().required('Required')}
+  validationSchema: {hello: Yup.string().required()}
 };
 
 const Template = args => {
@@ -38,102 +38,22 @@ const Template = args => {
       shouldRequireFieldUpdates={true}
       {...restArgs}
     >
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
-      <SQFormTextField
-        name="hello"
-        label="Hello"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
+      <SQFormTextField name="hello" label="Hello" size={12} />
     </SQFormScrollableCard>
   );
 

--- a/stories/SQFormScrollableCardsMenuWrapper.stories.js
+++ b/stories/SQFormScrollableCardsMenuWrapper.stories.js
@@ -34,7 +34,7 @@ function ScrollableDetails() {
   };
 
   const validationSchema = {
-    name: yup.string().required('Required')
+    name: yup.string().required()
   };
 
   const handleSubmit = (values, actions) => {
@@ -53,12 +53,7 @@ function ScrollableDetails() {
       validationSchema={validationSchema}
       title="notApplicableBecauseHeaderDisabled" // bug in SQFormScrollableCard bc it errors if no title prop even though it doesn't render its cardheader
     >
-      <SQFormTextField
-        name="name"
-        label="Name"
-        size={12}
-        isRequired={Boolean(validationSchema)}
-      />
+      <SQFormTextField name="name" label="Name" size={12} />
     </SQFormScrollableCard>
   );
 }

--- a/stories/SQFormTextField.stories.js
+++ b/stories/SQFormTextField.stories.js
@@ -47,9 +47,8 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  isRequired: true,
   schema: {
-    [defaultArgs.name]: Yup.string().required('Required')
+    [defaultArgs.name]: Yup.string().required()
   }
 };
 WithValidation.parameters = {

--- a/stories/SQFormTextarea.stories.js
+++ b/stories/SQFormTextarea.stories.js
@@ -47,9 +47,8 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  isRequired: true,
   schema: {
-    [defaultArgs.name]: Yup.string().required('Required')
+    [defaultArgs.name]: Yup.string().required()
   }
 };
 WithValidation.parameters = {

--- a/stories/__tests__/SQFormAsyncAutocomplete.stories.test.js
+++ b/stories/__tests__/SQFormAsyncAutocomplete.stories.test.js
@@ -137,20 +137,6 @@ describe('SQFormAsyncAutocomplete Tests', () => {
       expect(textField).toBeDisabled();
     });
 
-    it('should render as required when isRequired is true', () => {
-      render(<SQFormAsyncAutocomplete size="auto" isRequired={true} />);
-
-      const requiredText = screen.getByText(/required/i);
-      expect(requiredText).toBeVisible();
-    });
-
-    it('should not render as required when isRequired is false', () => {
-      render(<SQFormAsyncAutocomplete size="auto" isRequired={false} />);
-
-      const requiredText = screen.queryByText(/required/i);
-      expect(requiredText).not.toBeInTheDocument();
-    });
-
     it(`should display 'No options' when option not in the list is typed`, () => {
       render(<SQFormAsyncAutocomplete size="auto" />);
 
@@ -179,6 +165,21 @@ describe('SQFormAsyncAutocomplete Tests', () => {
   });
 
   describe('Autocomplete With Validation', () => {
+    it('should render as required when it is a required field', () => {
+      render(<SQFormAsyncAutocompleteWithValidation size="auto" />);
+
+      const requiredText = screen.getByText(/required/i);
+      expect(requiredText).toBeVisible();
+      expect(requiredText).toHaveClass('Mui-required');
+    });
+
+    it('should not render as required when it is not a required field', () => {
+      render(<SQFormAsyncAutocomplete size="auto" />);
+
+      const requiredText = screen.queryByText(/required/i);
+      expect(requiredText).not.toBeInTheDocument();
+    });
+
     it('should highlight field if required but no value selected', () => {
       render(<SQFormAsyncAutocompleteWithValidation size="auto" />);
 

--- a/stories/__tests__/SQFormAutocomplete.stories.test.js
+++ b/stories/__tests__/SQFormAutocomplete.stories.test.js
@@ -123,20 +123,6 @@ describe('SQFormAutocomplete Tests', () => {
       expect(textField).toBeDisabled();
     });
 
-    it('should render as required when isRequired is true', () => {
-      render(<SQFormAutocomplete size="auto" isRequired={true} />);
-
-      const requiredText = screen.getByText(/required/i);
-      expect(requiredText).toBeVisible();
-    });
-
-    it('should not render as required when isRequired is false', () => {
-      render(<SQFormAutocomplete size="auto" isRequired={false} />);
-
-      const requiredText = screen.queryByText(/required/i);
-      expect(requiredText).not.toBeInTheDocument();
-    });
-
     it('should display empty value when displayEmpty is true', () => {
       render(<SQFormAutocomplete size="auto" displayEmpty={true} />);
 
@@ -163,6 +149,21 @@ describe('SQFormAutocomplete Tests', () => {
   });
 
   describe('Autocomplete With Validation', () => {
+    it('should render as required when it is a required field', () => {
+      render(<SQFormAutocompleteWithValidation size="auto" />);
+
+      const requiredText = screen.getByText(/required/i);
+      expect(requiredText).toBeVisible();
+      expect(requiredText).toHaveClass('Mui-required');
+    });
+
+    it('should not render as required when it is not a required field', () => {
+      render(<SQFormAutocomplete size="auto" />);
+
+      const requiredText = screen.queryByText(/required/i);
+      expect(requiredText).not.toBeInTheDocument();
+    });
+
     it('should highlight field if required but no value selected', () => {
       render(<SQFormAutocompleteWithValidation size="auto" />);
 

--- a/stories/__tests__/SQFormCheckboxGroup.stories.test.js
+++ b/stories/__tests__/SQFormCheckboxGroup.stories.test.js
@@ -78,13 +78,6 @@ describe('SQFormCheckboxGroup Tests', () => {
       expect(checkboxLabel).not.toBeChecked();
     });
 
-    it('should render as required when isRequired is true', () => {
-      render(<SQFormCheckboxGroup size="auto" isRequired />);
-
-      const required = screen.getByText('Required');
-      expect(required).toBeInTheDocument();
-    });
-
     it('should render an extra checkbox when adding select all capability', () => {
       render(<SQFormCheckboxGroup size="auto" shouldUseSelectAll />);
 
@@ -226,13 +219,28 @@ describe('SQFormCheckboxGroup Tests', () => {
 
       userEvent.click(checkbox);
 
-      const required = screen.getByText('Required');
+      const required = screen.getByText(/Required/i);
       expect(required).toHaveClass('Mui-required');
 
       const submitButton = screen.getByRole('button', {
         name: /form submission/i
       });
       expect(submitButton).toBeDisabled();
+    });
+
+    it('should render as required when when its field is required', () => {
+      render(<SQFormCheckboxGroupWithValidation size="auto" />);
+
+      const required = screen.getByText(/Required/i);
+      expect(required).toBeInTheDocument();
+      expect(required).toHaveClass('Mui-required');
+    });
+
+    it('should not render as required when when its field is not required', () => {
+      render(<SQFormCheckboxGroup size="auto" />);
+
+      const required = screen.queryByText(/Required/i);
+      expect(required).not.toBeInTheDocument();
     });
   });
 });

--- a/stories/__tests__/SQFormDatePicker.stories.test.js
+++ b/stories/__tests__/SQFormDatePicker.stories.test.js
@@ -96,10 +96,9 @@ describe('SQFormDatePicker Tests', () => {
     //Data setup so the test won't need updating all the time
     const getTestDay = () => {
       const today = new Date();
-      const month = today.getMonth(); //January is 0
-      const currentMonth = month === 11 ? month : month + 1;
+      const month = today.getMonth() + 1; // .getMonth() returns a zero based month (0 = January)
 
-      return `${currentMonth}/01/${today.getFullYear()}`;
+      return `${month}/01/${today.getFullYear()}`;
     };
 
     const testDate = getTestDay();
@@ -119,16 +118,17 @@ describe('SQFormDatePicker Tests', () => {
     expect(textField).toBeDisabled();
   });
 
-  it('should display required text when isRequired is true', () => {
+  it('should initially display required text when it is a required field', () => {
     const SQFormProps = {
       initialValues: {
         date: ''
       }
     };
 
-    renderDatePicker({SQFormProps, isRequired: true});
+    renderDatePicker({SQFormProps});
 
     const required = screen.getByText(/required/i);
     expect(required).toBeVisible();
+    expect(required).toHaveClass('Mui-required');
   });
 });

--- a/stories/__tests__/SQFormDropdown.stories.test.js
+++ b/stories/__tests__/SQFormDropdown.stories.test.js
@@ -118,14 +118,22 @@ it('should be selectable if it is not disabled', () => {
 });
 
 it('should display icon and text if field is required', () => {
-  render(<SQFormDropdown isRequired size="auto" />);
+  const validationSchema = {
+    state: Yup.string().required()
+  };
+
+  render(<SQFormDropdown SQFormProps={{validationSchema}} size="auto" />);
 
   const required = screen.getByText(/required/i);
   expect(required).toBeVisible();
 });
 
 it('should not display icon and text if field is not required', () => {
-  render(<SQFormDropdown isRequired={false} size="auto" />);
+  const validationSchema = {
+    state: Yup.string()
+  };
+
+  render(<SQFormDropdown SQFormProps={{validationSchema}} size="auto" />);
 
   const required = screen.queryByText(/required/i);
   expect(required).not.toBeInTheDocument();
@@ -133,12 +141,10 @@ it('should not display icon and text if field is not required', () => {
 
 it('should highlight field if required but no value selected', () => {
   const validationSchema = {
-    state: Yup.string().required('Required')
+    state: Yup.string().required()
   };
 
-  render(
-    <SQFormDropdown isRequired SQFormProps={{validationSchema}} size="auto" />
-  );
+  render(<SQFormDropdown SQFormProps={{validationSchema}} size="auto" />);
 
   const expandButton = screen.getByRole('button', {name: /state/i});
 

--- a/stories/__tests__/SQFormMultiSelect.stories.test.js
+++ b/stories/__tests__/SQFormMultiSelect.stories.test.js
@@ -6,7 +6,10 @@ import {composeStories} from '@storybook/testing-react';
 import userEvent from '@testing-library/user-event';
 import * as stories from '../SQFormMultiSelect.stories';
 
-const {SQFormMultiSelect} = composeStories(stories);
+const {
+  SQFormMultiSelect,
+  WithValidation: SQFormMultiSelectWithValidation
+} = composeStories(stories);
 
 const initialDropdownValue = '- -';
 
@@ -147,10 +150,10 @@ describe('Tests for SQFormMultiSelect', () => {
     expect(optionsList).not.toBeInTheDocument();
   });
 
-  it('should display "required" helper text if field is required', async () => {
-    render(<SQFormMultiSelect isRequired={true} size="auto" />);
+  it('should initially render "Required" helper text if field is required', () => {
+    render(<SQFormMultiSelectWithValidation size="auto" />);
 
-    const required = await screen.findByText(/required/i);
+    const required = screen.getByText(/required/i);
     expect(required).toBeVisible();
   });
 
@@ -158,12 +161,12 @@ describe('Tests for SQFormMultiSelect', () => {
     render(<SQFormMultiSelect isRequired={false} size="auto" />);
 
     const required = screen.queryByText(/required/i);
-    await waitFor(() => expect(required).not.toBeInTheDocument());
+    expect(required).not.toBeInTheDocument();
   });
 
   it('should highlight field if required but no value selected', async () => {
     const validationSchema = {
-      friends: Yup.string().required('Required')
+      friends: Yup.string().required()
     };
 
     render(

--- a/stories/__tests__/SQFormMultiValue.stories.test.js
+++ b/stories/__tests__/SQFormMultiValue.stories.test.js
@@ -4,7 +4,10 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as stories from '../SQFormMultiValue.stories';
 
-const {Default: SQFormMultiValue} = composeStories(stories);
+const {
+  Default: SQFormMultiValue,
+  WithValidation: SQFormMultiValueWithValidation
+} = composeStories(stories);
 
 describe('SQFormMultiValue Tests', () => {
   it('renders a label, an input, and options', () => {
@@ -90,14 +93,15 @@ describe('SQFormMultiValue Tests', () => {
     expect(screen.queryByText('Required')).not.toBeInTheDocument();
   });
 
-  it('displays required text when field is required', () => {
+  it('should initially render "Required" helper text if field is required', () => {
     const SQFormProps = {
       initialValues: {
         favoriteColors: []
       }
     };
-    render(<SQFormMultiValue SQFormProps={SQFormProps} isRequired={true} />);
+    render(<SQFormMultiValueWithValidation SQFormProps={SQFormProps} />);
 
-    expect(screen.getByText('Required')).toBeVisible();
+    const required = screen.getByText('Required');
+    expect(required).toBeVisible();
   });
 });

--- a/stories/__tests__/SQFormTextField.stories.test.js
+++ b/stories/__tests__/SQFormTextField.stories.test.js
@@ -66,20 +66,6 @@ describe('SQFormTextField Tests', () => {
       expect(textField).not.toBeDisabled();
     });
 
-    it('should render as required when isRequired is true', () => {
-      render(<SQFormTextField size="auto" isRequired />);
-
-      const required = screen.getByText('Required');
-      expect(required).toBeInTheDocument();
-    });
-
-    it('should not render as required when isRequired is false', () => {
-      render(<SQFormTextField size="auto" isRequired={false} />);
-
-      const required = screen.queryByText('Required');
-      expect(required).not.toBeInTheDocument();
-    });
-
     it('should only render the number of characters equal to maxCharacters', () => {
       const maxCharacters = 5;
 
@@ -109,7 +95,14 @@ describe('SQFormTextField Tests', () => {
   });
 
   describe('Text Field With Validation', () => {
-    it('should highlight field if required by no value selected', () => {
+    it('should initially render "Required" helper text if field is required', () => {
+      render(<SQFormTextFieldWithValidation size="auto" />);
+
+      const required = screen.getByText('Required');
+      expect(required).toHaveClass('Mui-required');
+    });
+
+    it('should highlight field if required but no value selected', () => {
       render(<SQFormTextFieldWithValidation size="auto" />);
 
       userEvent.tab();

--- a/stories/__tests__/SQFormTextarea.stories.test.js
+++ b/stories/__tests__/SQFormTextarea.stories.test.js
@@ -68,20 +68,6 @@ describe('SQFormTextarea Tests', () => {
       expect(textbox).not.toBeDisabled();
     });
 
-    it('should render as required when isRequired is true', () => {
-      render(<SQFormTextarea size="auto" isRequired />);
-
-      const required = screen.getByText('Required');
-      expect(required).toBeInTheDocument();
-    });
-
-    it('should not render as required when isRequired is false', () => {
-      render(<SQFormTextarea size="auto" isRequired={false} />);
-
-      const required = screen.queryByText('Required');
-      expect(required).not.toBeInTheDocument();
-    });
-
     it('should only render the number of characters equal to maxCharacters', () => {
       const maxCharacters = 5;
 
@@ -115,6 +101,13 @@ describe('SQFormTextarea Tests', () => {
   });
 
   describe('Textarea With Validation', () => {
+    it('should initially render "Required" helper text if field is required', () => {
+      render(<SQFormTextareaWithValidation size="auto" />);
+
+      const required = screen.getByText('Required');
+      expect(required).toHaveClass('Mui-required');
+    });
+
     it('should highlight field if required by no value selected', () => {
       render(<SQFormTextareaWithValidation size="auto" />);
 


### PR DESCRIPTION
The required state of a form component is derived from the validation
schema

BREAKING CHANGE: 🧨 Removed the isRequired prop

✅ Closes: #472

✅  All Tests

Loom: https://www.loom.com/share/9179b8a1abb64cf88906791241282e5c