### PR TITLE
Added ability to hide the secondary button in the SQFormDialog

### DIFF
--- a/src/components/SQFormDialog/SQFormDialog.js
+++ b/src/components/SQFormDialog/SQFormDialog.js
@@ -20,7 +20,8 @@ function SQFormDialog({
   initialValues,
   muiGridProps = {},
   shouldRequireFieldUpdates = false,
-  validationSchema
+  validationSchema,
+  showSecondaryButton = true
 }) {
   const validationYupSchema = React.useMemo(() => {
     if (!validationSchema) return;
@@ -55,6 +56,7 @@ function SQFormDialog({
         shouldRequireFieldUpdates={shouldRequireFieldUpdates}
         title={title}
         muiGridProps={muiGridProps}
+        showSecondaryButton={showSecondaryButton}
       />
     </Formik>
   );
@@ -93,7 +95,9 @@ SQFormDialog.propTypes = {
    * Yup validation schema shape
    * https://jaredpalmer.com/formik/docs/guides/validation#validationschema
    * */
-  validationSchema: PropTypes.object
+  validationSchema: PropTypes.object,
+  /** show/hide the secondary Cancel button.  Defaults to show(true) */
+  showSecondaryButton: PropTypes.bool
 };
 
 export default SQFormDialog;

--- a/src/components/SQFormDialog/SQFormDialogInner.js
+++ b/src/components/SQFormDialog/SQFormDialogInner.js
@@ -186,7 +186,7 @@ SQFormDialogInner.propTypes = {
   title: PropTypes.string.isRequired,
   /** Any prop from https://material-ui.com/api/grid */
   muiGridProps: PropTypes.object,
-  /** show/hide the secondary Cancel button.  Defaults to show(true) */
+  /** show or hide the secondary Cancel button.  Defaults to show(true) */
   showSecondaryButton: PropTypes.bool
 };
 

--- a/src/components/SQFormDialog/SQFormDialogInner.js
+++ b/src/components/SQFormDialog/SQFormDialogInner.js
@@ -104,7 +104,7 @@ function SQFormDialogInner({
         maxWidth={maxWidth}
         open={isOpen}
         TransitionComponent={Transition}
-        onClose={handleCancel}
+        onClose={showSecondaryButton ? handleCancel : null}
       >
         <Form>
           <DialogTitle disableTypography={true} classes={titleClasses}>

--- a/src/components/SQFormDialog/SQFormDialogInner.js
+++ b/src/components/SQFormDialog/SQFormDialogInner.js
@@ -33,7 +33,7 @@ const useTitleStyles = makeStyles({
     borderBottom: ({palette}) => `1px solid ${palette.divider}`
   }
 });
-const useActionsStyles = makeStyles({
+const actionStyles = {
   root: {
     display: 'flex',
     justifyContent: 'space-between',
@@ -43,6 +43,10 @@ const useActionsStyles = makeStyles({
     bottom: 0,
     borderTop: ({palette}) => `1px solid ${palette.divider}`
   }
+};
+const useActionsStyles = makeStyles(actionStyles);
+const usePrimaryActionStyles = makeStyles({
+  root: {...actionStyles.root, justifyContent: 'flex-end'}
 });
 const useDialogContentStyles = makeStyles({
   root: {
@@ -63,11 +67,13 @@ function SQFormDialogInner({
   saveButtonText,
   shouldRequireFieldUpdates = false,
   title,
-  muiGridProps
+  muiGridProps,
+  showSecondaryButton = true
 }) {
   const theme = useTheme();
   const titleClasses = useTitleStyles(theme);
   const actionsClasses = useActionsStyles(theme);
+  const primaryActionsClasses = usePrimaryActionStyles(theme);
   const dialogContentClasses = useDialogContentStyles(theme);
   const {resetForm, dirty: isDirty} = useFormikContext();
 
@@ -113,15 +119,21 @@ function SQFormDialogInner({
               {children}
             </Grid>
           </DialogContent>
-          <DialogActions classes={actionsClasses}>
-            <RoundedButton
-              title={cancelButtonText}
-              onClick={handleCancel}
-              color="secondary"
-              variant="outlined"
-            >
-              {cancelButtonText}
-            </RoundedButton>
+          <DialogActions
+            classes={
+              showSecondaryButton ? actionsClasses : primaryActionsClasses
+            }
+          >
+            {showSecondaryButton && (
+              <RoundedButton
+                title={cancelButtonText}
+                onClick={handleCancel}
+                color="secondary"
+                variant="outlined"
+              >
+                {cancelButtonText}
+              </RoundedButton>
+            )}
             {onSave && (
               <SQFormButton
                 title={saveButtonText}
@@ -173,7 +185,9 @@ SQFormDialogInner.propTypes = {
   /** Title text at the top of the Dialog */
   title: PropTypes.string.isRequired,
   /** Any prop from https://material-ui.com/api/grid */
-  muiGridProps: PropTypes.object
+  muiGridProps: PropTypes.object,
+  /** show/hide the secondary Cancel button.  Defaults to show(true) */
+  showSecondaryButton: PropTypes.bool
 };
 
 export default SQFormDialogInner;

--- a/src/components/SQFormDialog/SQFormDialogInner.js
+++ b/src/components/SQFormDialog/SQFormDialogInner.js
@@ -104,7 +104,7 @@ function SQFormDialogInner({
         maxWidth={maxWidth}
         open={isOpen}
         TransitionComponent={Transition}
-        onClose={showSecondaryButton ? handleCancel : null}
+        onClose={showSecondaryButton ? handleCancel : undefined}
       >
         <Form>
           <DialogTitle disableTypography={true} classes={titleClasses}>

--- a/stories/SQFormDialog.stories.js
+++ b/stories/SQFormDialog.stories.js
@@ -30,7 +30,8 @@ const defaultArgs = {
   muiGridProps: {
     spacing: 2,
     alignItems: 'center'
-  }
+  },
+  showSecondaryButton: true
 };
 
 const Template = args => {

--- a/stories/__tests__/SQFormDatePicker.stories.test.js
+++ b/stories/__tests__/SQFormDatePicker.stories.test.js
@@ -96,7 +96,7 @@ describe('SQFormDatePicker Tests', () => {
     //Data setup so the test won't need updating all the time
     const getTestDay = () => {
       const today = new Date();
-      const month = today.getMonth() + 1; // .getMonth() returns a zero based month (0 = January)
+      const month = ('0' + (today.getMonth() + 1)).slice(-2); // .getMonth() returns a zero based month (0 = January)
 
       return `${month}/01/${today.getFullYear()}`;
     };

--- a/stories/__tests__/SQFormDatePicker.stories.test.js
+++ b/stories/__tests__/SQFormDatePicker.stories.test.js
@@ -97,10 +97,10 @@ describe('SQFormDatePicker Tests', () => {
     const getTestDay = () => {
       const today = new Date();
       const month = today.getMonth() + 1; // .getMonth() returns a zero based month (0 = January)
-      //Data setup so the test won't need updating all the time
-      const formatMonth = month < 10 ? `0${month}` : month;
+      // The month should have a leading zero if only one digit
+      const monthString = month >= 10 ? month.toString() : `0${month}`;
 
-      return `${formatMonth}/01/${today.getFullYear()}`;
+      return `${monthString}/01/${today.getFullYear()}`;
     };
 
     const testDate = getTestDay();

--- a/stories/__tests__/SQFormDatePicker.stories.test.js
+++ b/stories/__tests__/SQFormDatePicker.stories.test.js
@@ -96,9 +96,11 @@ describe('SQFormDatePicker Tests', () => {
     //Data setup so the test won't need updating all the time
     const getTestDay = () => {
       const today = new Date();
-      const month = ('0' + (today.getMonth() + 1)).slice(-2); // .getMonth() returns a zero based month (0 = January)
+      const month = today.getMonth() + 1; // .getMonth() returns a zero based month (0 = January)
+      //Data setup so the test won't need updating all the time
+      const formatMonth = month < 10 ? `0${month}` : month;
 
-      return `${month}/01/${today.getFullYear()}`;
+      return `${formatMonth}/01/${today.getFullYear()}`;
     };
 
     const testDate = getTestDay();

--- a/stories/__tests__/SQFormDialog.stories.test.js
+++ b/stories/__tests__/SQFormDialog.stories.test.js
@@ -114,10 +114,25 @@ it('should not call onClose on `escape` keydown because cancel is not available'
     code: 'Escape'
   });
 
+  await waitFor(() => {
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+});
+
+it('should not find the cancel secondary button', async () => {
+  render(
+    <Default
+      isOpen={true}
+      onSave={handleSave}
+      onClose={handleClose}
+      showSecondaryButton={false}
+    />
+  );
+
   expect(screen.queryByRole('button', {name: /cancel/i})).toBeNull();
 
   await waitFor(() => {
-    expect(handleClose).toHaveBeenCalledTimes(0);
+    expect(handleClose).not.toHaveBeenCalled();
   });
 });
 

--- a/stories/__tests__/SQFormDialog.stories.test.js
+++ b/stories/__tests__/SQFormDialog.stories.test.js
@@ -96,6 +96,31 @@ describe('Tests for Default', () => {
   });
 });
 
+it('should not call onClose on `escape` keydown because cancel is not available', async () => {
+  render(
+    <Default
+      isOpen={true}
+      onSave={handleSave}
+      onClose={handleClose}
+      showSecondaryButton={false}
+    />
+  );
+
+  // fireEvent, not userEvent
+  // to confirm the 'key' and 'code' values-- > https://keycode.info/
+  // https://testing-library.com/docs/dom-testing-library/api-events/ --> find 'keyboard events'
+  fireEvent.keyDown(screen.getByRole('presentation'), {
+    key: 'Escape',
+    code: 'Escape'
+  });
+
+  expect(screen.queryByRole('button', {name: /cancel/i})).toBeNull();
+
+  await waitFor(() => {
+    expect(handleClose).toHaveBeenCalledTimes(0);
+  });
+});
+
 describe('Tests for WithValidation', () => {
   it('should disable submit/save until validationSchema satisfied', async () => {
     render(

--- a/stories/__tests__/SQFormDialog.stories.test.js
+++ b/stories/__tests__/SQFormDialog.stories.test.js
@@ -130,10 +130,6 @@ it('should not find the cancel secondary button', async () => {
   );
 
   expect(screen.queryByRole('button', {name: /cancel/i})).toBeNull();
-
-  await waitFor(() => {
-    expect(handleClose).not.toHaveBeenCalled();
-  });
 });
 
 describe('Tests for WithValidation', () => {


### PR DESCRIPTION
UX has requested we offer a way to hide the secondary button to enforce users to take an action in a dialog.  

Closes: #482 

Loom: https://www.loom.com/share/3469d74003e5468991249b27f832d4ef