### PR TITLE
fix: 🐛 Type error on build

### DIFF
--- a/src/components/SQForm/SQFormReadOnlyField.tsx
+++ b/src/components/SQForm/SQFormReadOnlyField.tsx
@@ -21,7 +21,7 @@ function SQFormReadOnlyField({
 }: SQFormReadOnlyFieldProps): React.ReactElement {
   const {
     formikField: {field},
-  } = useForm({name, isRequired: false});
+  } = useForm({name});
 
   return (
     <Grid item sm={size}>


### PR DESCRIPTION
While resolving some merge conflicts for a separate PR of mine I found this error.

It looks like the interface for useForm removed isRequired.
SQFormReadOnlyField was sending it and it cause a type error. 

So I remove the isRequired param on the call to useForm in SQFormReadOnlyFiled. 