### PR TITLE
fix: 🐛 add style prop for container of guided workflow

### DIFF
--- a/src/components/SQFormGuidedWorkflow/PropTypes.js
+++ b/src/components/SQFormGuidedWorkflow/PropTypes.js
@@ -108,5 +108,7 @@ export const GuidedWorkflowProps = {
   onError: PropTypes.func.isRequired,
   /** Task Module configuration Object(s) */
   taskModules: PropTypes.arrayOf(PropTypes.shape(TaskModuleProps).isRequired)
-    .isRequired
+    .isRequired,
+  /** An object of css-in-js style properties to be passed */
+  containerStyles: PropTypes.object
 };

--- a/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.js
+++ b/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.js
@@ -51,7 +51,8 @@ function SQFormGuidedWorkflow({
   mainSubtitle,
   initialCompletedTasks = 0,
   isStrictMode = false,
-  onError
+  onError,
+  containerStyles = {}
 }) {
   const classes = useStyles();
 
@@ -176,7 +177,7 @@ function SQFormGuidedWorkflow({
   });
 
   return (
-    <Section style={{padding: '20px'}}>
+    <Section style={{padding: '20px', ...containerStyles}}>
       <SectionHeader title={mainTitle} informativeHeading={mainSubtitle} />
       <SectionBody>
         <Accordion accordionPanels={transformedTaskModules} />


### PR DESCRIPTION
We need to pass a dynamic style to the container of SQFormGuidedWorkflow. currently we have <Section style={{padding: '20px'}}>
Which is fixed to 20px. In senior, we need a dynamic padding in our scenario we need it to 0px.
That's why we need a style prop.