### PR TITLE
refactor: 💡 Add generics to useForm hook

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,7 +48,13 @@
       "plugins": ["@typescript-eslint"],
       "rules": {
         "no-use-before-define": "off",
-        "@typescript-eslint/no-use-before-define": ["error"]
+        "@typescript-eslint/no-use-before-define": ["error"],
+        "@typescript-eslint/no-explicit-any": [
+          "error",
+          {
+            "ignoreRestArgs": true
+          }
+        ]
       }
     }
   ]

--- a/src/components/SQForm/SQFormCheckboxGroup.tsx
+++ b/src/components/SQForm/SQFormCheckboxGroup.tsx
@@ -25,7 +25,7 @@ interface SQFormCheckboxGroupProps {
   /** Whether a selection in this group is required */
   isRequired?: boolean;
   /** Function to call on value change */
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: CheckboxProps['onChange'];
   /** Whether to display the group in a row */
   shouldDisplayInRow?: boolean;
   /** Whether to display the select all checkbox */
@@ -48,7 +48,10 @@ function SQFormCheckboxGroup({
   const {
     fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {handleChange, handleBlur, HelperTextComponent},
-  } = useForm({name, onChange});
+  } = useForm<CheckboxOption['value'][], React.ChangeEvent<HTMLInputElement>>({
+    name,
+    onChange,
+  });
 
   const {setFieldValue} = useFormikContext();
 

--- a/src/components/SQForm/SQFormCheckboxGroupItem.tsx
+++ b/src/components/SQForm/SQFormCheckboxGroupItem.tsx
@@ -3,6 +3,7 @@ import {FormControlLabel, CheckboxProps} from '@material-ui/core';
 import Checkbox from '@material-ui/core/Checkbox';
 import {makeStyles} from '@material-ui/core/styles';
 import {useForm} from './useForm';
+import {Option} from 'types';
 
 const useStyles = makeStyles((theme) => ({
   checkboxGroupItem: {
@@ -21,7 +22,7 @@ interface SQFormCheckboxGroupItemProps {
   /** Value for the checkbox */
   value: string | boolean | number;
   /** Function to call when input value is changed */
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: CheckboxProps['onChange'];
   /** Whether this group item is part of a group displayed in a row */
   isRowDisplay?: boolean;
   /** Whether the checkbox is disabled */
@@ -42,7 +43,10 @@ function SQFormCheckboxGroupItem({
   const {
     formikField: {field},
     fieldHelpers: {handleChange},
-  } = useForm({name: groupName, onChange});
+  } = useForm<
+    Option['value'][] | Option['value'],
+    React.ChangeEvent<HTMLInputElement>
+  >({name: groupName, onChange});
 
   const classes = useStyles();
 

--- a/src/components/SQForm/SQFormDropdown.tsx
+++ b/src/components/SQForm/SQFormDropdown.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import FormControl from '@material-ui/core/FormControl';
-import Select from '@material-ui/core/Select';
+import Select, {SelectProps} from '@material-ui/core/Select';
 import Input from '@material-ui/core/Input';
 import MenuItem from '@material-ui/core/MenuItem';
 import InputLabel from '@material-ui/core/InputLabel';
@@ -16,9 +15,29 @@ import {
   getUndefinedValueWarning,
 } from '../../utils/consoleWarnings';
 import {EMPTY_LABEL} from '../../utils/constants';
+import {BaseFieldProps, Option} from 'types';
+
+interface SQFormDropdownProps extends BaseFieldProps {
+  /** Dropdown options to select from */
+  children: Option[];
+  /** Whether to display empty option - - in options */
+  displayEmpty?: boolean;
+  /** Disabled property to disable the input if true */
+  isDisabled?: boolean;
+  /** Custom onBlur event callback */
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
+  /** Custom onChange event callback */
+  onChange?: SelectProps['onChange'];
+  /** Any valid prop for material ui select child component - https://material-ui.com/api/select/#props  */
+  muiFieldProps?: SelectProps;
+}
 
 const EMPTY_VALUE = '';
-const EMPTY_OPTION = {label: EMPTY_LABEL, value: EMPTY_VALUE};
+const EMPTY_OPTION = {
+  label: EMPTY_LABEL,
+  value: EMPTY_VALUE,
+  isDisabled: false,
+};
 
 const useStyles = makeStyles({
   selectHeight: {
@@ -38,7 +57,7 @@ function SQFormDropdown({
   onChange,
   size = 'auto',
   muiFieldProps = {},
-}) {
+}: SQFormDropdownProps): React.ReactElement {
   const classes = useStyles();
 
   const {
@@ -72,7 +91,7 @@ function SQFormDropdown({
     return [EMPTY_OPTION, ...children];
   }, [children, displayEmpty, name]);
 
-  const renderValue = (value) => {
+  const renderValue = (value: Option['value']) => {
     if (value === undefined || value === null) {
       console.warn(getUndefinedValueWarning('SQFormDropdown', name));
       return EMPTY_LABEL;
@@ -86,7 +105,9 @@ function SQFormDropdown({
       (option) => option.value === value
     )?.label;
     if (!valueToRender) {
-      console.warn(getOutOfRangeValueWarning('SQFormDropdown', name, value));
+      console.warn(
+        getOutOfRangeValueWarning('SQFormDropdown', name, value.toString())
+      );
       return undefined;
     }
 
@@ -112,15 +133,17 @@ function SQFormDropdown({
           onBlur={handleBlur}
           onChange={handleChange}
           labelId={labelID}
-          renderValue={renderValue}
+          renderValue={(value: unknown) =>
+            renderValue(value as Option['value'])
+          }
           {...muiFieldProps}
         >
           {options.map((option) => {
             return (
               <MenuItem
-                key={option.value}
+                key={`${name}_${option.value}`}
                 disabled={option.isDisabled}
-                value={option.value}
+                value={`${option.value}`}
               >
                 {option.label}
               </MenuItem>
@@ -132,36 +155,5 @@ function SQFormDropdown({
     </Grid>
   );
 }
-
-SQFormDropdown.propTypes = {
-  /** Dropdown options to select from */
-  children: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string,
-      value: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-        PropTypes.bool,
-      ]),
-      isDisabled: PropTypes.bool,
-    })
-  ),
-  /** Whether to display empty option - - in options */
-  displayEmpty: PropTypes.bool,
-  /** Disabled property to disable the input if true */
-  isDisabled: PropTypes.bool,
-  /** Label text */
-  label: PropTypes.string.isRequired,
-  /** Name identifier of the input field */
-  name: PropTypes.string.isRequired,
-  /** Custom onBlur event callback */
-  onBlur: PropTypes.func,
-  /** Custom onChange event callback */
-  onChange: PropTypes.func,
-  /** Size of the input given full-width is 12. */
-  size: PropTypes.oneOf(['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-  /** Any valid prop for material ui select child component - https://material-ui.com/api/select/#props  */
-  muiFieldProps: PropTypes.object,
-};
 
 export default SQFormDropdown;

--- a/src/components/SQForm/SQFormRadioButtonGroup.tsx
+++ b/src/components/SQForm/SQFormRadioButtonGroup.tsx
@@ -3,6 +3,7 @@ import {
   Grid,
   RadioGroup,
   RadioProps,
+  RadioGroupProps,
   FormHelperText,
   FormControl,
   FormLabel,
@@ -24,7 +25,7 @@ interface SQFormRadioButtonGroupProps {
   /** Size of the input given full-width is 12. */
   size?: GridSize;
   /** Function to call on value change */
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: RadioGroupProps['onChange'];
   /** Whether this radio selection is required */
   isRequired?: boolean;
   /** Whether to display group in row */
@@ -47,7 +48,15 @@ function SQFormRadioButtonGroup({
     fieldState: {isFieldError, isFieldRequired},
     formikField: {field},
     fieldHelpers: {handleChange, handleBlur, HelperTextComponent},
-  } = useForm({name, onChange});
+  } = useForm<
+    RadioButtonInputItemProps['value'],
+    React.ChangeEvent<HTMLInputElement>
+  >({
+    name,
+    onChange,
+  });
+
+  console.log('field', field);
 
   const childrenToRadioGroupItems = () => {
     return children.map((radioOption) => {

--- a/src/components/SQForm/SQFormTextarea.tsx
+++ b/src/components/SQForm/SQFormTextarea.tsx
@@ -17,7 +17,7 @@ interface SQFormTextareaProps extends BaseFieldProps {
   /** Custom onBlur event callback */
   onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
   /** Custom onChange event callback */
-  onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
+  onChange?: TextFieldProps['onChange'];
   /** Number of rows to display when multiline option is set to true. */
   rows?: number;
   /** Maximum number of rows to display when multiline option is set to true. */
@@ -56,7 +56,7 @@ function SQFormTextarea({
       handleChange: handleChangeHelper,
       HelperTextComponent,
     },
-  } = useForm({
+  } = useForm<string, React.ChangeEvent<HTMLInputElement>>({
     name,
     onBlur,
     onChange,

--- a/src/components/SQForm/useForm.tsx
+++ b/src/components/SQForm/useForm.tsx
@@ -10,17 +10,22 @@ import isEqual from 'lodash.isequal';
 import WarningIcon from '@material-ui/icons/NewReleases';
 import VerifiedIcon from '@material-ui/icons/VerifiedUser';
 
-interface UseFormParam {
+type ChangeHandler<TChangeEvent> = (
+  event: TChangeEvent,
+  ...args: any[]
+) => void;
+
+interface UseFormParam<TChangeEvent> {
   name: string;
   onBlur?: React.FocusEventHandler;
-  onChange?: React.ChangeEventHandler;
+  onChange?: ChangeHandler<TChangeEvent>;
 }
 
-interface UseFormReturn {
+interface UseFormReturn<TValue, TChangeEvent> {
   formikField: {
-    field: FieldInputProps<unknown>;
-    meta: FieldMetaProps<unknown>;
-    helpers: FieldHelperProps<unknown>;
+    field: FieldInputProps<TValue>;
+    meta: FieldMetaProps<TValue>;
+    helpers: FieldHelperProps<TValue>;
   };
   fieldState: {
     errorMessage: string;
@@ -32,7 +37,7 @@ interface UseFormReturn {
   };
   fieldHelpers: {
     handleBlur: React.FocusEventHandler;
-    handleChange: React.ChangeEventHandler;
+    handleChange: ChangeHandler<TChangeEvent>;
     HelperTextComponent: React.ReactElement | string;
   };
 }
@@ -63,10 +68,14 @@ function _getHasValue(meta: FieldMetaProps<unknown>) {
   return !!fieldValue;
 }
 
-export function useForm({name, onBlur, onChange}: UseFormParam): UseFormReturn {
+export function useForm<TValue, TChangeEvent>({
+  name,
+  onBlur,
+  onChange,
+}: UseFormParam<TChangeEvent>): UseFormReturn<TValue, TChangeEvent> {
   _handleError(name);
 
-  const [field, meta, helpers] = useField(name);
+  const [field, meta, helpers] = useField<TValue>(name);
   const errorMessage = getIn(meta, 'error');
   const isTouched = getIn(meta, 'touched');
   const isDirty = !isEqual(meta.initialValue, meta.value);
@@ -92,7 +101,7 @@ export function useForm({name, onBlur, onChange}: UseFormParam): UseFormReturn {
   const isFieldError = getFieldStatus() === 'ERROR';
   const isFulfilled = getFieldStatus() === 'USER_FULFILLED';
 
-  const handleChange = React.useCallback(
+  const handleChange: ChangeHandler<TChangeEvent> = React.useCallback(
     (event) => {
       field.onChange(event);
       onChange && onChange(event);


### PR DESCRIPTION
Added generics to useForm hook. Also converted SQFormMultiSelect to TS
and SQFormDropdown to TS, and updated other components that use the hook
as proof that the generics work

✅ Closes: #337
✅ Closes: #394
✅ Closes: #332 
See #338 for conversation, code, and loom videos that explain the situation _super_ well and was largely the inspiration for the changes in this PR.