### PR TITLE
fix: 🐛 Update deprecated justify prop for Grid

### DIFF
--- a/src/components/SQForm/SQFormHelperText.js
+++ b/src/components/SQForm/SQFormHelperText.js
@@ -80,7 +80,7 @@ function SQFormHelperText({
   return (
     <Grid
       container
-      justify="flex-end"
+      justifyContent="flex-end"
       wrap="nowrap"
       alignItems="center"
       className={`${classes.wrapper} ${classes[helperTextType]}`}

--- a/src/components/SQFormDialogStepper/SQFormDialogStepper.js
+++ b/src/components/SQFormDialogStepper/SQFormDialogStepper.js
@@ -224,7 +224,7 @@ export function SQFormDialogStepper({
                 {...muiGridProps}
                 container
                 spacing={muiGridProps.spacing ?? 3}
-                justify="center"
+                justifyContent="center"
               >
                 {currentChild}
               </Grid>
@@ -249,7 +249,11 @@ export function SQFormDialogStepper({
 
 SQFormDialogStep.propTypes = {
   /** The content to be rendered in the step body. */
-  children: PropTypes.oneOfType([PropTypes.element, PropTypes.elementType]),
+  children: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.elementType,
+    PropTypes.node
+  ]),
   /** Should the loading spinner be shown */
   isLoading: PropTypes.bool,
   /** Optional message to be added to the loading spinner */

--- a/stories/SQForm.stories.js
+++ b/stories/SQForm.stories.js
@@ -220,7 +220,7 @@ export const BasicForm = () => {
           {MOCK_MULTI_VALUE_OPTIONS}
         </SQFormMultiValue>
         <Grid item sm={12}>
-          <Grid container justify="space-between">
+          <Grid container justifyContent="space-between">
             <SQFormResetButtonWithConfirmation
               variant="outlined"
               confirmationContent="You are about to reset this form. Any unsaved info for this customer will be removed"
@@ -310,7 +310,7 @@ export const FormWithValidation = () => {
           {MOCK_MULTI_VALUE_OPTIONS}
         </SQFormMultiValue>
         <Grid item sm={12}>
-          <Grid container justify="space-between">
+          <Grid container justifyContent="space-between">
             <SQFormButton title="Reset" type="reset">
               RESET
             </SQFormButton>
@@ -354,7 +354,7 @@ export const formWithFieldArray = () => {
           <FriendsFieldArray name="friends" />
         </Grid>
         <Grid item sm={12}>
-          <Grid container justify="flex-end">
+          <Grid container justifyContent="flex-end">
             <SQFormButton shouldRequireFieldUpdates={true}>Submit</SQFormButton>
           </Grid>
         </Grid>
@@ -444,7 +444,7 @@ export const formWithInclusionlist = () => {
           }}
         </SQFormInclusionList>
         <Grid item sm={12}>
-          <Grid container justify="space-between">
+          <Grid container justifyContent="space-between">
             <SQFormResetButtonWithConfirmation
               variant="outlined"
               confirmationContent="You are about to reset this form. Any unsaved info for this customer will be removed"
@@ -472,7 +472,7 @@ export const basicFormWithMultiSelect = () => {
         validationSchema={validationSchema}
         muiGridProps={{
           spacing: 2,
-          justify: 'space-between',
+          justifyContent: 'space-between',
           alignItems: 'center'
         }}
       >
@@ -514,7 +514,7 @@ export const basicFormWithMaskedFields = () => {
         validationSchema={validationSchema}
         muiGridProps={{
           spacing: 2,
-          justify: 'space-between',
+          justifyContent: 'space-between',
           alignItems: 'center'
         }}
       >
@@ -568,7 +568,7 @@ export const basicFormWithMaskedFields = () => {
           mask={[/[A-Z]/i, /\d/, /[A-Z]/i, ' ', /\d/, /[A-Z]/i, /\d/]}
         />
         <Grid item sm={12}>
-          <Grid container justify="space-between">
+          <Grid container justifyContent="space-between">
             <SQFormResetButtonWithConfirmation
               variant="outlined"
               confirmationContent="You are about to reset this form. Any unsaved info for this customer will be removed"
@@ -625,7 +625,7 @@ export const basicFormWithCustomOnBlur = () => {
           {MOCK_STATE_OPTIONS}
         </SQFormDropdown>
         <Grid item sm={12}>
-          <Grid container justify="flex-end">
+          <Grid container justifyContent="flex-end">
             <SQFormButton>Submit</SQFormButton>
           </Grid>
         </Grid>
@@ -676,7 +676,7 @@ export const basicFormWithCustomOnChange = () => {
           {MOCK_STATE_OPTIONS}
         </SQFormDropdown>
         <Grid item sm={12}>
-          <Grid container justify="flex-end">
+          <Grid container justifyContent="flex-end">
             <SQFormButton>Submit</SQFormButton>
           </Grid>
         </Grid>
@@ -698,7 +698,7 @@ export const applyAnAction = () => {
         validationSchema={validationSchema}
         muiGridProps={{
           spacing: 2,
-          justify: 'space-between',
+          justifyContent: 'space-between',
           alignItems: 'center'
         }}
       >
@@ -754,7 +754,7 @@ export const SQFormCheckboxGroupExample = () => {
           {CHECKBOX_GROUP_OPTIONS}
         </SQFormCheckboxGroup>
         <Grid item sm={12}>
-          <Grid container justify="flex-end">
+          <Grid container justifyContent="flex-end">
             <SQFormButton>Submit</SQFormButton>
           </Grid>
         </Grid>
@@ -786,7 +786,7 @@ export const ccaChecklist = () => {
         validationSchema={validationSchema}
         muiGridProps={{
           spacing: 2,
-          justify: 'space-between',
+          justifyContent: 'space-between',
           alignItems: 'center'
         }}
       >

--- a/stories/SQFormDialogStepper.stories.js
+++ b/stories/SQFormDialogStepper.stories.js
@@ -55,7 +55,9 @@ const booleanOptions = [
 
 const defaultArgs = {
   onSubmit: handleSubmit,
-  initialValues: {...personalDataInitialValues, ...accountDetailsInitValues}
+  initialValues: {...personalDataInitialValues, ...accountDetailsInitValues},
+  isOpen: false,
+  onClose: () => {}
 };
 
 export const Default = args => {


### PR DESCRIPTION
The justify prop on Grid components was renamed to justifyContent. After
updating that I noticed that SQFormDialogStepper had 2 new error logs.
So I added defaults for missing required props and added a type to the
children PropTypes.

✅ Closes: #499