### PR TITLE
test: 💍 Remove test of removed type SQFormIconButton

### DIFF
--- a/stories/__tests__/SQFormIconButton.stories.test.js
+++ b/stories/__tests__/SQFormIconButton.stories.test.js
@@ -42,17 +42,6 @@ describe('SQFormIconButton Tests', () => {
       expect(iconButton).toHaveAttribute('type', 'reset');
     });
 
-    it('should render a button given the type button', () => {
-      render(<SQFormIconButton exampleIcons={CheckCircle} type="button" />);
-
-      const iconButton = screen.getByRole('button', {
-        name: /form submission/i
-      });
-
-      expect(iconButton).toBeInTheDocument();
-      expect(iconButton).toHaveAttribute('type', 'button');
-    });
-
     it('should call a function when clicked', () => {
       const onClickSpy = jest.fn();
       render(


### PR DESCRIPTION
In the tests for SQFormIconButton there was one that was testing the
type 'button'. However, that type is no longer a valid one. So removing
that test stops the warning log.

✅ Closes: #501