### PR TITLE
fix: 🐛 Fixed components using boolean valued options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,60 @@ For **BREAKING CHANGES** Type a brief description of the breaking change when as
 
 ## Breaking Changes
 
+### Version `[Typescript Version]`
+In SQForm v`[Typescript Version]` support for `boolean` valued dropdown options was removed. Material-UI and HTML Select components do not support options with `boolean`s as values and causes type conflicts with our own library. Therefore, if you're upgrading this version and you using `boolean` values options you'll need to take care to update those. Below is our recommended changes.
+
+```js
+// ⛔️ Example
+const YES_NO_DROPDOWN_OPTIONS = [
+  {label: 'Yes', value: true},
+  {label: 'No', value: false}
+];
+
+// ✅ Example
+const YES_NO_DROPDOWN_OPTIONS = [
+  {label: 'Yes', value: 1},
+  {label: 'No', value: 0}
+]
+```
+
+Be sure that when you change your dropdown options that you take care to update your submit, onChange, and onBlur handlers such that you're taking into account that the values for the affected forms will no longer be `boolean`s. Using `1` and `0` will still allow for `if(dropdownValue)` to evaluate correctly. However, if you're expecting your values to be passed as booleans outside of any event handlers you'll need to use `Boolean(dropdownValue)`. See an example below of how one might update an SQForm submit handler to comply with this breaking change.
+
+```js
+const updateSurveyAnswer = (surveyAnswer: boolean) => {
+  // Example
+  sendNetworkRequest({
+    url,
+    method: 'GET',
+    body: {
+      questionID: 1,
+      answer: surveryAnswer,
+    }
+  });
+};
+
+// ⛔️ Outdated submit handler
+type FormValues = {
+  surveyAnswer: boolean;
+};
+
+const handleSubmit = (formValues: FormValues) => {
+  updateSurveryAnswer(formValues.surveryAnswer);
+};
+
+// ✅ Updated submit handler
+type FormValues = {
+  // Now is `number` or whatever new type your dropdown options will be
+  surveryAnswer: number;
+}
+
+const handleSubmit = (formValues: FormValues) => {
+  updateSurveryAnswer(Boolean(formValues.surveryAnswer));
+});
+```
+
+Lastly, you'll also need to make sure you update your Yup validation for the affected form fields from `Yup.boolean()` to `Yup.number()` or whatever new value type you're using for your affected dropdown options.
+
 ### Version 6
 
 In SQForm v6, we no longer need to pass the `isRequired` prop to any form components. The components now derive whether or not they are a required field based on the Yup validation schema of the form.
@@ -63,7 +117,7 @@ setLocale({
 During this time, please search the project for validation schemas that use `array()`. If they are `required`.
 Please ensure `.required()` is the FIRST validation method in the chain.
 
-```
+```js
 // ✅ Example
 options: Yup.array()
   .required()

--- a/src/components/SQForm/SQFormDropdown.tsx
+++ b/src/components/SQForm/SQFormDropdown.tsx
@@ -91,27 +91,35 @@ function SQFormDropdown({
     return [EMPTY_OPTION, ...children];
   }, [children, displayEmpty, name]);
 
-  const renderValue = (value: Option['value']) => {
-    if (value === undefined || value === null) {
-      console.warn(getUndefinedValueWarning('SQFormDropdown', name));
-      return EMPTY_LABEL;
-    }
+  const renderValue = (value: unknown) => {
+    const getValue = (selectedValue: Option['value']) => {
+      if (selectedValue === undefined || selectedValue === null) {
+        console.warn(getUndefinedValueWarning('SQFormDropdown', name));
+        return EMPTY_LABEL;
+      }
 
-    if (value === EMPTY_VALUE) {
-      return EMPTY_LABEL;
-    }
+      if (selectedValue === EMPTY_VALUE) {
+        return EMPTY_LABEL;
+      }
 
-    const valueToRender = options.find(
-      (option) => option.value === value
-    )?.label;
-    if (!valueToRender) {
-      console.warn(
-        getOutOfRangeValueWarning('SQFormDropdown', name, value.toString())
-      );
-      return undefined;
-    }
+      const valueToRender = options.find(
+        (option) => option.value === selectedValue
+      )?.label;
+      if (!valueToRender) {
+        console.warn(
+          getOutOfRangeValueWarning(
+            'SQFormDropdown',
+            name,
+            selectedValue.toString()
+          )
+        );
+        return undefined;
+      }
 
-    return valueToRender;
+      return valueToRender;
+    };
+
+    return getValue(value as Option['value']);
   };
 
   return (
@@ -133,9 +141,7 @@ function SQFormDropdown({
           onBlur={handleBlur}
           onChange={handleChange}
           labelId={labelID}
-          renderValue={(value: unknown) =>
-            renderValue(value as Option['value'])
-          }
+          renderValue={renderValue}
           {...muiFieldProps}
         >
           {options.map((option) => {
@@ -143,7 +149,7 @@ function SQFormDropdown({
               <MenuItem
                 key={`${name}_${option.value}`}
                 disabled={option.isDisabled}
-                value={`${option.value}`}
+                value={option.value}
               >
                 {option.label}
               </MenuItem>

--- a/src/components/SQForm/SQFormMultiSelect.tsx
+++ b/src/components/SQForm/SQFormMultiSelect.tsx
@@ -192,12 +192,16 @@ function SQFormMultiSelect({
    * this handles scenarios where label and value are not the same,
    * e.g., if value is an "ID"
    */
-  const getRenderValue = (selected: Option['value'][]) => {
-    if (!selected?.length) {
-      return EMPTY_LABEL;
-    }
+  const getRenderValue = (selected: unknown) => {
+    const getValue = (selectedValues: Option['value'][]) => {
+      if (!selectedValues?.length) {
+        return EMPTY_LABEL;
+      }
 
-    return selectedDisplayValue(selected, children, name);
+      return selectedDisplayValue(selectedValues, children, name);
+    };
+
+    return getValue(selected as Option['value'][]);
   };
 
   const renderTooltip = () => {
@@ -236,9 +240,7 @@ function SQFormMultiSelect({
             onChange={handleMultiSelectChange}
             fullWidth={true}
             labelId={labelID}
-            renderValue={(selected: unknown) =>
-              getRenderValue(selected as Option['value'][])
-            }
+            renderValue={getRenderValue}
             MenuProps={MenuProps}
             onOpen={toggleTooltip}
             onClose={toggleTooltip}
@@ -259,10 +261,7 @@ function SQFormMultiSelect({
             )}
             {children?.map((option) => {
               return (
-                <MenuItem
-                  key={`${name}_${option.value}`}
-                  value={`${option.value}`}
-                >
+                <MenuItem key={`${name}_${option.value}`} value={option.value}>
                   <Checkbox checked={field.value?.includes(option.value)} />
                   <ListItemText
                     primary={option.label}

--- a/src/types/Option.ts
+++ b/src/types/Option.ts
@@ -1,4 +1,4 @@
-export type optionValue = string | number | boolean;
+export type optionValue = string | number;
 
 interface Option {
   /** Label of the option */

--- a/stories/SQFormDropdown.stories.js
+++ b/stories/SQFormDropdown.stories.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import * as Yup from 'yup';
 
 import {SQFormDropdown as SQFormDropdownComponent} from '../src';
 import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
@@ -42,21 +41,6 @@ const defaultArgs = {
   },
 };
 
-const YES_NO_OPTIONS = [
-  {label: 'Yes', value: true},
-  {label: 'No', value: false},
-];
-
-const booleanValueArgs = {
-  label: 'Opt in?',
-  name: 'isOptIn',
-  children: YES_NO_OPTIONS,
-  schema: {isOptIn: Yup.bool().required()},
-  SQFormProps: {
-    initialValues: {isOptIn: false},
-  },
-};
-
 const Template = (args) => {
   const {SQFormProps, schema, size, ...dropdownProps} = args;
   return (
@@ -75,7 +59,3 @@ const Template = (args) => {
 export const Default = Template.bind({});
 Default.args = defaultArgs;
 Default.storyName = 'SQFormDropdown';
-
-export const BooleanValued = Template.bind({});
-BooleanValued.args = booleanValueArgs;
-BooleanValued.storyName = 'BooleanValues';


### PR DESCRIPTION
Fixed SQFormDropdown and SQFormMultiSelect components from using boolean
valued options. Now, options are no longer allowed to be boolean valued

BREAKING CHANGE: 🧨 Components options are no longer allowed to have boolean values

✅ Closes: #504