### PR TITLE
fix: 🐛 SQFormAutocomplete fix JSS warning

### DIFF
--- a/src/components/SQForm/SQFormAutocomplete.js
+++ b/src/components/SQForm/SQFormAutocomplete.js
@@ -187,7 +187,8 @@ const useAutocompleteStyles = makeStyles({
   popper: {
     borderRadius: '4px',
     boxShadow: '0px 3px 4px 0px rgb(100 100 100)',
-    width: ({lockWidthToField}) => (!lockWidthToField ? 'auto !important' : ''),
+    width: ({lockWidthToField}) =>
+      !lockWidthToField ? 'auto !important' : undefined,
     overflowX: 'hidden !important'
   },
   paper: {


### PR DESCRIPTION
While running tests for SQFormAutocomplete, the same warning is thrown every test. 
`Warning: [JSS] Cannot set property 'parentStyleSheet' of undefined`
This was solved by returning undefined instead of empty string so that the conditional styles would not be included if they were not needed (instead of setting them to empty string)

Loom: https://www.loom.com/share/46fbdd0781e14e07bc7a4130080dba0c

✅ Closes: #510