### PR TITLE
fix: 🐛 Update deprecated props SQFormTextarea

### DIFF
--- a/src/components/SQForm/SQFormTextarea.js
+++ b/src/components/SQForm/SQFormTextarea.js
@@ -72,8 +72,8 @@ function SQFormTextarea({
         onChange={handleChange}
         onBlur={handleBlur}
         required={isFieldRequired}
-        rows={rows}
-        rowsMax={rowsMax}
+        minRows={rows}
+        maxRows={rowsMax}
         variant="outlined"
         value={values[name]}
         inputProps={{


### PR DESCRIPTION
The props rows and rowsMax for SQFormTextarea are deprecated. Now we
need to use minRows and maxRows. However, in order to avoid a breaking
change, I left the original prop names intact and only updated the prop
names we send to the underlying Mui component.

✅ Closes: #517