### PR TITLE
refactor: 💡 Migrate SFormDialogStepper tests to TS

### DIFF
--- a/stories/__tests__/SQFormDialogStepper.stories.test.tsx
+++ b/stories/__tests__/SQFormDialogStepper.stories.test.tsx
@@ -10,10 +10,12 @@ const {
   WithValidation: SQFormDialogStepperWithValidation,
 } = composeStories(stories);
 
-window.alert = jest.fn();
+const mockAlert = jest.fn();
+
+window.alert = mockAlert;
 
 afterEach(() => {
-  window.alert.mockClear();
+  mockAlert.mockClear();
 });
 
 describe('SQFormDialogStepper Tests', () => {


### PR DESCRIPTION
✅ Closes: #588

Actually changing the file to TS. Somehow the first time the file extension went from `js` to `jsx` instead of `tsx`. So fixed it.