### PR TITLE
refactor: 💡 Rename poorly named exposed types

### DIFF
--- a/src/components/SQForm/SQFormAsyncAutocomplete.tsx
+++ b/src/components/SQForm/SQFormAsyncAutocomplete.tsx
@@ -10,7 +10,7 @@ import {Typography} from '@material-ui/core';
 import {getIn, useField, useFormikContext} from 'formik';
 import {usePrevious} from '@selectquotelabs/sqhooks';
 import {useForm} from './useForm';
-import type {Option} from 'types';
+import type {SQFormOption} from 'types';
 import {
   ListboxVirtualizedComponentProps,
   OuterElementContextInterface,
@@ -221,7 +221,7 @@ function SQFormAsyncAutocomplete({
         inputValue={inputValue}
         disabled={isDisabled}
         getOptionLabel={(option) => option.label}
-        getOptionDisabled={(option: Option) => option.isDisabled || false}
+        getOptionDisabled={(option: SQFormOption) => option.isDisabled || false}
         renderInput={(params) => {
           return (
             <TextField

--- a/src/components/SQForm/SQFormAutocomplete.tsx
+++ b/src/components/SQForm/SQFormAutocomplete.tsx
@@ -13,12 +13,12 @@ import {VariableSizeList} from 'react-window';
 import type {ListChildComponentProps} from 'react-window';
 import {getIn, useField, useFormikContext} from 'formik';
 import {usePrevious} from '@selectquotelabs/sqhooks';
-import type {BaseFieldProps, Option, optionValue} from 'types';
+import type {BaseFieldProps, SQFormOption} from 'types';
 import {useForm} from './useForm';
 
 export interface SQFormAutocompleteProps extends BaseFieldProps {
   /** Dropdown menu options to select from */
-  children: Option[];
+  children: SQFormOption[];
   /** Disabled property to disable the input if true */
   isDisabled?: boolean;
   /** Required property used to highlight input and label if not fulfilled */
@@ -30,13 +30,13 @@ export interface SQFormAutocompleteProps extends BaseFieldProps {
   /** Custom onChange event callback */
   onChange?: (
     event: React.ChangeEvent<HTMLInputElement>,
-    selectedValue: optionValue,
+    selectedValue: SQFormOption['value'],
     reason: AutocompleteChangeReason
   ) => void;
   /** Custom onInputChange event callback (key pressed) */
   onInputChange?: (
     event: React.ChangeEvent<HTMLInputElement>,
-    value: optionValue
+    value: SQFormOption['value']
   ) => void;
   /** Lock width of the dropdown to the width of the field in the form */
   lockWidthToField?: boolean;
@@ -192,8 +192,8 @@ const ListboxVirtualizedComponent = React.forwardRef<HTMLDivElement>(
 );
 
 const getInitialValue = (
-  children: Option[],
-  value: optionValue,
+  children: SQFormOption[],
+  value: SQFormOption['value'],
   displayEmpty: boolean
 ) => {
   const optionInitialValue = children?.find((option) => {
@@ -354,7 +354,9 @@ function SQFormAutocomplete({
         disableClearable={isDisabled}
         disabled={isDisabled}
         getOptionLabel={(option) => option.label || ''}
-        getOptionDisabled={(option: Option) => option?.isDisabled || false}
+        getOptionDisabled={(option: SQFormOption) =>
+          option?.isDisabled || false
+        }
         renderInput={(params) => {
           return (
             <TextField

--- a/src/components/SQForm/SQFormButton.tsx
+++ b/src/components/SQForm/SQFormButton.tsx
@@ -3,7 +3,7 @@ import {RoundedButton} from 'scplus-shared-components';
 import {useFormButton, BUTTON_TYPES} from './useFormButton';
 import type {ButtonType} from './useFormButton';
 
-export interface Props {
+export interface SQFormButtonProps {
   children: React.ReactNode;
   isDisabled?: boolean;
   shouldRequireFieldUpdates?: boolean;
@@ -19,7 +19,7 @@ function SQFormButton({
   title,
   type = 'submit',
   onClick,
-}: Props): JSX.Element {
+}: SQFormButtonProps): JSX.Element {
   const isResetButton = type === BUTTON_TYPES.RESET;
   const {isButtonDisabled, handleReset, handleClick} = useFormButton({
     isDisabled,

--- a/src/components/SQForm/SQFormCheckboxGroupItem.tsx
+++ b/src/components/SQForm/SQFormCheckboxGroupItem.tsx
@@ -4,7 +4,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import type {CheckboxProps} from '@material-ui/core';
 import {makeStyles} from '@material-ui/core/styles';
 import {useForm} from './useForm';
-import type {Option} from 'types';
+import type {SQFormOption} from 'types';
 
 const useStyles = makeStyles((theme) => ({
   checkboxGroupItem: {
@@ -45,7 +45,7 @@ function SQFormCheckboxGroupItem({
     formikField: {field},
     fieldHelpers: {handleChange},
   } = useForm<
-    Option['value'][] | Option['value'],
+    SQFormOption['value'][] | SQFormOption['value'],
     React.ChangeEvent<HTMLInputElement>
   >({name: groupName, onChange});
 

--- a/src/components/SQForm/SQFormDropdown.tsx
+++ b/src/components/SQForm/SQFormDropdown.tsx
@@ -16,11 +16,11 @@ import {
   getUndefinedValueWarning,
 } from '../../utils/consoleWarnings';
 import {EMPTY_LABEL} from '../../utils/constants';
-import type {BaseFieldProps, Option} from 'types';
+import type {BaseFieldProps, SQFormOption} from 'types';
 
 export interface SQFormDropdownProps extends BaseFieldProps {
   /** Dropdown options to select from */
-  children: Option[];
+  children: SQFormOption[];
   /** Whether to display empty option - - in options */
   displayEmpty?: boolean;
   /** Disabled property to disable the input if true */
@@ -93,7 +93,7 @@ function SQFormDropdown({
   }, [children, displayEmpty, name]);
 
   const renderValue = (value: unknown) => {
-    const getValue = (selectedValue: Option['value']) => {
+    const getValue = (selectedValue: SQFormOption['value']) => {
       if (selectedValue === undefined || selectedValue === null) {
         console.warn(getUndefinedValueWarning('SQFormDropdown', name));
         return EMPTY_LABEL;
@@ -120,7 +120,7 @@ function SQFormDropdown({
       return valueToRender;
     };
 
-    return getValue(value as Option['value']);
+    return getValue(value as SQFormOption['value']);
   };
 
   return (

--- a/src/components/SQForm/SQFormInclusionList.tsx
+++ b/src/components/SQForm/SQFormInclusionList.tsx
@@ -4,7 +4,7 @@ import type {GridProps} from '@material-ui/core';
 import {useFormikContext, FieldArray, FieldArrayRenderProps} from 'formik';
 import SQFormInclusionListItem from './SQFormInclusionListItem';
 import type {SQFormInclusionListItemProps} from './SQFormInclusionListItem';
-import type {Option} from 'types';
+import type {SQFormOption} from 'types';
 
 export interface SQFormInclusionListProps {
   /** the `name` must match the name of the desired array in `initialValues` */
@@ -12,7 +12,7 @@ export interface SQFormInclusionListProps {
   /** boolean flag to trigger usage of Select All functionality */
   useSelectAll?: boolean;
   /** array of items to put in the `name` array on 'select all' click */
-  selectAllData?: Option['value'][];
+  selectAllData?: SQFormOption['value'][];
   /** props for the Grid container wrapping the select all checkbox */
   selectAllContainerProps?: GridProps;
   /** props for the 'select all' SQFormInclusionListItem component */

--- a/src/components/SQForm/SQFormMaskedReadOnlyField.tsx
+++ b/src/components/SQForm/SQFormMaskedReadOnlyField.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import MaskedInput from 'react-text-mask';
-import type {maskProp} from 'types';
+import type {Mask} from 'types';
 import SQFormReadOnlyField from './SQFormReadOnlyField';
 import type {SQFormReadOnlyFieldProps} from './SQFormReadOnlyField';
 
 interface TextFieldMaskProps extends React.HTMLAttributes<HTMLInputElement> {
   inputRef?: (ref: HTMLElement | null) => void;
   /** Valid mask array; custom or from utils/masks.js */
-  mask?: maskProp;
+  mask?: Mask;
 }
 
 export interface SQFormMaskedReadOnlyFieldProps
   extends SQFormReadOnlyFieldProps {
   /** Valid mask array; custom or from utils/masks.js */
-  mask?: maskProp;
+  mask?: Mask;
   /** Placeholder text used inside the input field to provide hints to the user */
   placeholder?: string;
 }

--- a/src/components/SQForm/SQFormMaskedTextField.tsx
+++ b/src/components/SQForm/SQFormMaskedTextField.tsx
@@ -1,20 +1,20 @@
 import {useFormikContext} from 'formik';
 import React from 'react';
 import MaskedInput from 'react-text-mask';
-import type {maskProp} from 'types';
+import type {Mask} from 'types';
 import SQFormTextField from './SQFormTextField';
 import type {SQFormTextFieldProps} from './SQFormTextField';
 
 export interface SQFormMaskedTextFieldProps extends SQFormTextFieldProps {
   /** Valid mask array; custom or from utils/masks.js */
-  mask?: maskProp;
+  mask?: Mask;
   /** Whether the submitted value from the input should have all non-numeric characters removed */
   stripNonNumeric?: boolean;
 }
 
 interface TextFieldMaskProps extends React.HTMLAttributes<HTMLInputElement> {
   inputRef?: (ref: HTMLElement | null) => void;
-  mask?: maskProp;
+  mask?: Mask;
 }
 
 function TextFieldMask({

--- a/src/components/SQForm/SQFormMultiSelect.tsx
+++ b/src/components/SQForm/SQFormMultiSelect.tsx
@@ -21,17 +21,17 @@ import {
   getUndefinedChildrenWarning,
   getUndefinedValueWarning,
 } from '../../utils/consoleWarnings';
-import type {BaseFieldProps, Option} from 'types';
+import type {BaseFieldProps, SQFormOption} from 'types';
 
 export interface SQFormMultiSelectProps extends BaseFieldProps {
   /** Multiselect options to select from */
-  children: Option[];
+  children: SQFormOption[];
   /** Disabled property to disable the input if true */
   isDisabled?: boolean;
   /** Custom onChange event callback */
   onChange?: (
     event: React.ChangeEvent<{name?: string; value: unknown}>,
-    value: Option['value'][]
+    value: SQFormOption['value'][]
   ) => void;
   /** This property will allow the end user to check a "Select All" box */
   useSelectAll?: boolean;
@@ -66,7 +66,7 @@ const MenuProps = {
 } as SelectProps['MenuProps'];
 
 const selectedDisplayValue = (
-  values: Option['value'][],
+  values: SQFormOption['value'][],
   options: SQFormMultiSelectProps['children'],
   name?: SQFormMultiSelectProps['name']
 ) => {
@@ -89,7 +89,7 @@ const selectedDisplayValue = (
 };
 
 const getToolTipTitle = (
-  formikFieldValue: Option['value'][],
+  formikFieldValue: SQFormOption['value'][],
   options: SQFormMultiSelectProps['children']
 ) => {
   if (!formikFieldValue?.length) {
@@ -128,7 +128,7 @@ function SQFormMultiSelect({
     formikField: {field},
     fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {handleBlur, HelperTextComponent},
-  } = useForm<Option['value'][], unknown>({name});
+  } = useForm<SQFormOption['value'][], unknown>({name});
 
   React.useEffect(() => {
     if (!children) {
@@ -143,16 +143,16 @@ function SQFormMultiSelect({
   const labelID = label.toLowerCase();
   const toolTipTitle = getToolTipTitle(field.value, children);
 
-  const getIsSelectAllChecked = (value: Option['value'][]) =>
+  const getIsSelectAllChecked = (value: SQFormOption['value'][]) =>
     value.includes('ALL');
-  const getIsSelectNoneChecked = (value: Option['value'][]) =>
+  const getIsSelectNoneChecked = (value: SQFormOption['value'][]) =>
     value.includes('NONE');
 
   const getValues = (
     children: SQFormMultiSelectProps['children'],
     isSelectAllChecked: boolean,
     isSelectNoneChecked: boolean,
-    value: Option['value'][]
+    value: SQFormOption['value'][]
   ) => {
     if (isSelectAllChecked) {
       return children?.map((option) => option.value);
@@ -169,7 +169,7 @@ function SQFormMultiSelect({
     event: React.ChangeEvent<{name?: string; value: unknown}>,
     _child: ReactNode
   ) => {
-    const value = event.target.value as unknown as Option['value'][];
+    const value = event.target.value as unknown as SQFormOption['value'][];
     const isSelectAllChecked = getIsSelectAllChecked(value);
     const isSelectNoneChecked = getIsSelectNoneChecked(value);
     const values = getValues(
@@ -192,7 +192,7 @@ function SQFormMultiSelect({
    * e.g., if value is an "ID"
    */
   const getRenderValue = (selected: unknown) => {
-    const getValue = (selectedValues: Option['value'][]) => {
+    const getValue = (selectedValues: SQFormOption['value'][]) => {
       if (!selectedValues?.length) {
         return EMPTY_LABEL;
       }
@@ -200,7 +200,7 @@ function SQFormMultiSelect({
       return selectedDisplayValue(selectedValues, children, name);
     };
 
-    return getValue(selected as Option['value'][]);
+    return getValue(selected as SQFormOption['value'][]);
   };
 
   const renderTooltip = () => {
@@ -234,7 +234,7 @@ function SQFormMultiSelect({
             multiple
             displayEmpty
             input={<Input disabled={isDisabled} name={name} />}
-            value={(field.value as Option['value'][]) || []}
+            value={(field.value as SQFormOption['value'][]) || []}
             onBlur={handleBlur}
             onChange={handleMultiSelectChange}
             fullWidth={true}

--- a/src/components/SQForm/SQFormMultiValue.tsx
+++ b/src/components/SQForm/SQFormMultiValue.tsx
@@ -9,7 +9,7 @@ import type {ListChildComponentProps} from 'react-window';
 import {useField, useFormikContext} from 'formik';
 import {usePrevious} from '@selectquotelabs/sqhooks';
 import {useForm} from './useForm';
-import type {BaseFieldProps, Option, optionValue} from 'types';
+import type {BaseFieldProps, SQFormOption} from 'types';
 import type {
   OuterElementContextInterface,
   OuterElementTypeProps,
@@ -17,7 +17,7 @@ import type {
 
 export interface SQFormMultiValueProps extends BaseFieldProps {
   /** options to select from */
-  children: Option[];
+  children: SQFormOption[];
   /** Whether the field is required */
   isRequired?: boolean;
   /** Whether the field is disabled */
@@ -25,13 +25,13 @@ export interface SQFormMultiValueProps extends BaseFieldProps {
   /** Custom handler for input value change */
   onInputChange?: (
     event: React.ChangeEvent<HTMLInputElement>,
-    value: optionValue
+    value: SQFormOption['value']
   ) => void;
   onChange?: (
     event: React.ChangeEvent<HTMLInputElement>,
-    value: (string | Option)[],
+    value: (string | SQFormOption)[],
     reason: AutocompleteChangeReason,
-    detail?: string | Option
+    detail?: string | SQFormOption
   ) => void;
   /** Custom onBlur event callback */
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
@@ -138,7 +138,7 @@ function SQFormMultiValue({
   });
 
   const [inputValue, setInputValue] = React.useState('');
-  const [customOptions, setCustomOptions] = React.useState<Option[]>([]);
+  const [customOptions, setCustomOptions] = React.useState<SQFormOption[]>([]);
   const displayOptions = React.useMemo(
     () => [...children, ...customOptions],
     [children, customOptions]
@@ -157,8 +157,8 @@ function SQFormMultiValue({
       return option.value;
     });
 
-    const newCustomOptions: Option[] = initialValue.reduce(
-      (acc: Option[], value: optionValue): Option[] => {
+    const newCustomOptions: SQFormOption[] = initialValue.reduce(
+      (acc: SQFormOption[], value: SQFormOption['value']): SQFormOption[] => {
         if (displayValues.includes(value)) {
           return acc;
         }
@@ -199,7 +199,7 @@ function SQFormMultiValue({
         /* Creating an option we always know that the last value
          * in the `value` array is a string
          */
-        const newCustomOption: Option = {
+        const newCustomOption: SQFormOption = {
           label: value[value.length - 1],
           value: value[value.length - 1],
         };

--- a/src/components/SQForm/SQFormTextField.tsx
+++ b/src/components/SQForm/SQFormTextField.tsx
@@ -3,7 +3,7 @@ import {TextField} from '@material-ui/core';
 import type {TextFieldProps, InputProps} from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import type {BaseFieldProps, maskProp} from 'types';
+import type {BaseFieldProps, Mask} from 'types';
 
 import {useForm} from './useForm';
 import {toKebabCase} from '../../utils';
@@ -28,7 +28,7 @@ export interface SQFormTextFieldProps extends BaseFieldProps {
   /** Props applied to the Input element */
   InputProps?: InputProps;
   /** Attributes applied to the `input` element */
-  inputProps?: React.InputHTMLAttributes<HTMLInputElement> & {mask?: maskProp};
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement> & {mask?: Mask};
   /** Defines the maximum number of characters the user can enter into the field; mapped to `input` element `maxlength` attribute */
   maxCharacters?: number;
   /** Any valid prop for material ui text input child component - https://material-ui.com/api/text-field/#props */

--- a/src/components/SQFormGuidedWorkflow/AdditionalInformationSection.tsx
+++ b/src/components/SQFormGuidedWorkflow/AdditionalInformationSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Section, SectionBody} from 'scplus-shared-components';
 import Header from './Header';
-import type {AdditionalInformationProps} from './Types';
+import type {SQFormGuidedWorkflowAdditionalInformationProps} from './Types';
 
 function AdditionalInformationSection({
   actions,
@@ -12,7 +12,7 @@ function AdditionalInformationSection({
   successText,
   isFailedState,
   Elements,
-}: AdditionalInformationProps): React.ReactElement {
+}: SQFormGuidedWorkflowAdditionalInformationProps): React.ReactElement {
   return (
     <Section>
       <Header

--- a/src/components/SQFormGuidedWorkflow/AgentScript.tsx
+++ b/src/components/SQFormGuidedWorkflow/AgentScript.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Section, SectionBody, ScriptedText} from 'scplus-shared-components';
 import Header from './Header';
-import type {AgentScriptProps} from './Types';
+import type {SQFormGuidedWorkflowAgentScriptProps} from './Types';
 
 function AgentScript({
   actions,
@@ -12,7 +12,7 @@ function AgentScript({
   successText,
   isFailedState,
   text,
-}: AgentScriptProps): React.ReactElement {
+}: SQFormGuidedWorkflowAgentScriptProps): React.ReactElement {
   return (
     <Section>
       <Header

--- a/src/components/SQFormGuidedWorkflow/Header.tsx
+++ b/src/components/SQFormGuidedWorkflow/Header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {useFormikContext} from 'formik';
 import {SectionHeader} from 'scplus-shared-components';
-import type {HeaderProps} from './Types';
+import type {SQFormGuidedWorkflowHeaderProps} from './Types';
 
 const helperTextType = {
   info: 'info',
@@ -18,7 +18,7 @@ function Header({
   errorText,
   successText,
   isFailedState = false,
-}: HeaderProps): React.ReactElement {
+}: SQFormGuidedWorkflowHeaderProps): React.ReactElement {
   const {isValid, touched} = useFormikContext();
   const isFormTouched = Object.keys(touched).length;
 

--- a/src/components/SQFormGuidedWorkflow/OutcomeForm.tsx
+++ b/src/components/SQFormGuidedWorkflow/OutcomeForm.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Grid} from '@material-ui/core';
 import {Section, SectionBody} from 'scplus-shared-components';
 import Header from './Header';
-import type {OutcomeProps} from './Types';
+import type {SQFormGuidedWorkflowOutcomeProps} from './Types';
 
 function OutcomeForm({
   actions,
@@ -14,7 +14,7 @@ function OutcomeForm({
   successText,
   isFailedState,
   muiGridProps = {},
-}: OutcomeProps): React.ReactElement {
+}: SQFormGuidedWorkflowOutcomeProps): React.ReactElement {
   return (
     <Section>
       <Header

--- a/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.tsx
+++ b/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.tsx
@@ -16,7 +16,10 @@ import OutcomeForm from './OutcomeForm';
 import AdditionalInformationSection from './AdditionalInformationSection';
 import {useManageTaskModules} from './useManageTaskModules';
 import {useGuidedWorkflowContext} from './useGuidedWorkflowContext';
-import type {SQFormDataProps, SQFormGuidedWorkflowProps} from './Types';
+import type {
+  SQFormGuidedWorkflowDataProps,
+  SQFormGuidedWorkflowProps,
+} from './Types';
 
 const useStyles = makeStyles(() => {
   return {
@@ -48,7 +51,7 @@ function SQFormGuidedWorkflow<TValues extends {[key: string]: unknown}>({
   // Until Formik exposes the validationSchema (again) via Context, the solution has to be handled at the Form declaration level
   // There's a few open PR's on this issue, here's one for reference: https://github.com/formium/formik/pull/2933
   const getFormikInitialRequiredErrors = (
-    validationSchema?: SQFormDataProps<TValues>['validationSchema']
+    validationSchema?: SQFormGuidedWorkflowDataProps<TValues>['validationSchema']
   ) => {
     if (validationSchema) {
       return Object.entries(validationSchema).reduce((acc, [key, value]) => {

--- a/src/components/SQFormGuidedWorkflow/Types.ts
+++ b/src/components/SQFormGuidedWorkflow/Types.ts
@@ -3,7 +3,7 @@ import type {GridProps} from '@material-ui/core';
 import type {FormikHelpers} from 'formik';
 import type {AnySchema} from 'yup';
 
-export interface HeaderProps {
+export interface SQFormGuidedWorkflowHeaderProps {
   /** Title to display in the section header */
   title: string;
   /** Optional elements to display in the section header */
@@ -26,30 +26,33 @@ export interface HeaderProps {
   isFailedState?: boolean;
 }
 
-export interface AdditionalInformationProps extends HeaderProps {
+export interface SQFormGuidedWorkflowAdditionalInformationProps
+  extends SQFormGuidedWorkflowHeaderProps {
   Elements: React.ReactElement;
 }
 
-export interface AgentScriptProps extends HeaderProps {
+export interface SQFormGuidedWorkflowAgentScriptProps
+  extends SQFormGuidedWorkflowHeaderProps {
   /** Scripted Text for the user to read */
   text: string;
 }
 
-export interface OutcomeProps extends HeaderProps {
+export interface SQFormGuidedWorkflowOutcomeProps
+  extends SQFormGuidedWorkflowHeaderProps {
   /** SQForm Elements to render inside the Form */
   FormElements: React.ReactElement;
   /** Any props from MUI <Grid> component */
   muiGridProps?: GridProps;
 }
 
-export interface SQFormDataProps<TValues> {
+export interface SQFormGuidedWorkflowDataProps<TValues> {
   /** Form Entity Object aka initial values of the form */
   initialValues: TValues;
   /** Form Submission Handler | @typedef onSubmit: (values: Values, formikBag: FormikBag, context) => void | Promise<any> */
   onSubmit: (
     values: TValues,
     formikBag: FormikHelpers<TValues>,
-    context: Context<TValues>
+    context: SQFormGuidedWorkflowContext<TValues>
   ) => void | Promise<unknown>;
   /** Yup validation schema shape */
   validationSchema?: Record<
@@ -58,19 +61,19 @@ export interface SQFormDataProps<TValues> {
   >;
 }
 
-export interface TaskModuleProps<TValues> {
+export interface SQFormGuidedWorkflowTaskModuleProps<TValues> {
   /** Unique name used as a key for managing expansion state within Accordion */
   name: string;
   /** Title text */
   title: string;
   /** The props used to configure SQForm */
-  formikProps: SQFormDataProps<TValues>;
+  formikProps: SQFormGuidedWorkflowDataProps<TValues>;
   /** The props used to configured the Additional Information section */
-  additionalInformationSectionProps?: AdditionalInformationProps;
+  additionalInformationSectionProps?: SQFormGuidedWorkflowAdditionalInformationProps;
   /** The props used to configure the Scripted Text section */
-  scriptedTextProps: AgentScriptProps;
+  scriptedTextProps: SQFormGuidedWorkflowAgentScriptProps;
   /** The props used to configure the Outcome form section */
-  outcomeProps: OutcomeProps;
+  outcomeProps: SQFormGuidedWorkflowOutcomeProps;
   /** Subtitle text - Each Subtitle is separated by a pipe "|" */
   subtitles?: Array<string>;
   /** Panel is disabled, the user cannot toggle the panel while disabled */
@@ -101,7 +104,7 @@ export interface SQFormGuidedWorkflowProps<
   /** Main Subtitle Informative Text */
   mainSubtitle: string;
   /** Task Module configuration Object(s) */
-  taskModules: Array<TaskModuleProps<TValues>>;
+  taskModules: Array<SQFormGuidedWorkflowTaskModuleProps<TValues>>;
   /** Number of tasks completed (Default is zero) */
   initialCompletedTasks?: number;
   /**
@@ -118,50 +121,10 @@ export interface SQFormGuidedWorkflowProps<
   containerStyles?: React.CSSProperties;
 }
 
-export type GuidedWorkflowDispatchActionType<TValues> = {
-  type: 'UPDATE';
-  id: number;
-  data: TValues;
-};
-
-export type ManageTaskModulesUpdateActionType = {
-  type: 'UPDATE_ACTIVE_TASK_MODULE';
-  id: number;
-};
-
-export type ManageTaskModulesNextActionType = {
-  type: 'ENABLE_NEXT_TASK_MODULE';
-};
-
-export type ManageTaskModulesResetActionType = {
-  type: 'RESET_TO_INITIAL_STATE';
-};
-
-export type ManageTaskModulesActionType =
-  | ManageTaskModulesUpdateActionType
-  | ManageTaskModulesNextActionType
-  | ManageTaskModulesResetActionType;
-
-export type ManageTaskModulesState = {
-  activeTaskModuleID: number;
-  progressTaskModuleID: number;
-};
-
-export type Context<TValues> = {
+export type SQFormGuidedWorkflowContext<TValues> = {
   [key: number]: {
     name: string;
     data: TValues;
     isDisabled: boolean;
   };
-};
-
-export type UseGuidedWorkflowContextType<TValues> = {
-  state: Context<TValues>;
-  updateDataByID: (id: number, data: TValues) => void;
-};
-
-export type UseManageTaskModulesType = {
-  taskModulesState: ManageTaskModulesState;
-  updateActiveTaskModule: (taskNumber: number) => void;
-  enableNextTaskModule: () => void;
 };

--- a/src/components/SQFormGuidedWorkflow/useGuidedWorkflowContext.ts
+++ b/src/components/SQFormGuidedWorkflow/useGuidedWorkflowContext.ts
@@ -1,15 +1,24 @@
 import React from 'react';
 import type {
-  TaskModuleProps,
-  Context,
-  GuidedWorkflowDispatchActionType,
-  UseGuidedWorkflowContextType,
+  SQFormGuidedWorkflowTaskModuleProps,
+  SQFormGuidedWorkflowContext,
 } from './Types';
 
+type GuidedWorkflowDispatchActionType<TValues> = {
+  type: 'UPDATE';
+  id: number;
+  data: TValues;
+};
+
+type UseGuidedWorkflowContextType<TValues> = {
+  state: SQFormGuidedWorkflowContext<TValues>;
+  updateDataByID: (id: number, data: TValues) => void;
+};
+
 export function useGuidedWorkflowContext<TValues>(
-  taskModules: Array<TaskModuleProps<TValues>>
+  taskModules: Array<SQFormGuidedWorkflowTaskModuleProps<TValues>>
 ): UseGuidedWorkflowContextType<TValues> {
-  const initialData = taskModules.reduce<Context<TValues>>(
+  const initialData = taskModules.reduce<SQFormGuidedWorkflowContext<TValues>>(
     (acc, taskModule, index) => {
       return {
         ...acc,
@@ -24,12 +33,12 @@ export function useGuidedWorkflowContext<TValues>(
   );
 
   const reducer = (
-    prevState: Context<TValues>,
+    prevState: SQFormGuidedWorkflowContext<TValues>,
     action: GuidedWorkflowDispatchActionType<TValues>
   ) => {
     switch (action.type) {
       case 'UPDATE':
-        return taskModules.reduce<Context<TValues>>(
+        return taskModules.reduce<SQFormGuidedWorkflowContext<TValues>>(
           (acc, taskModlue, index) => {
             const taskID = index + 1;
             const prevData = prevState[taskID].data;

--- a/src/components/SQFormGuidedWorkflow/useManageTaskModules.ts
+++ b/src/components/SQFormGuidedWorkflow/useManageTaskModules.ts
@@ -1,10 +1,34 @@
 import React from 'react';
-import type {
-  Context,
-  ManageTaskModulesActionType,
-  ManageTaskModulesState,
-  UseManageTaskModulesType,
-} from './Types';
+import type {SQFormGuidedWorkflowContext} from './Types';
+
+type ManageTaskModulesUpdateActionType = {
+  type: 'UPDATE_ACTIVE_TASK_MODULE';
+  id: number;
+};
+
+type ManageTaskModulesNextActionType = {
+  type: 'ENABLE_NEXT_TASK_MODULE';
+};
+
+type ManageTaskModulesResetActionType = {
+  type: 'RESET_TO_INITIAL_STATE';
+};
+
+type UseManageTaskModulesType = {
+  taskModulesState: ManageTaskModulesState;
+  updateActiveTaskModule: (taskNumber: number) => void;
+  enableNextTaskModule: () => void;
+};
+
+type ManageTaskModulesActionType =
+  | ManageTaskModulesUpdateActionType
+  | ManageTaskModulesNextActionType
+  | ManageTaskModulesResetActionType;
+
+type ManageTaskModulesState = {
+  activeTaskModuleID: number;
+  progressTaskModuleID: number;
+};
 
 const getInitialTaskModuleID = (
   initialCompletedTasks: number,
@@ -18,7 +42,7 @@ const getInitialTaskModuleID = (
 
 export function useManageTaskModules<TValues>(
   initialCompletedTasks: number,
-  taskModulesContext: Context<TValues>
+  taskModulesContext: SQFormGuidedWorkflowContext<TValues>
 ): UseManageTaskModulesType {
   const taskModulesLength = Object.keys(taskModulesContext).length;
   const firstTaskModuleID = Number(Object.keys(taskModulesContext)[0]);

--- a/src/types/MaskTypes.ts
+++ b/src/types/MaskTypes.ts
@@ -1,4 +1,4 @@
 import type {maskArray} from 'react-text-mask';
-type maskProp = maskArray | ((value: string) => maskArray);
+type Mask = maskArray | ((value: string) => maskArray);
 
-export default maskProp;
+export default Mask;

--- a/src/types/Option.ts
+++ b/src/types/Option.ts
@@ -1,12 +1,12 @@
-export type optionValue = string | number;
+export type SQFormOptionValue = string | number;
 
-interface Option {
+interface SQFormOption {
   /** Label of the option */
   label: string;
   /** Value of the option */
-  value: optionValue;
+  value: SQFormOptionValue;
   /** Whether the option is disabled */
   isDisabled?: boolean;
 }
 
-export default Option;
+export default SQFormOption;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,3 @@
 export type {default as BaseFieldProps} from './BaseFieldProps';
-export type {default as Option, optionValue} from './Option';
-export type {default as maskProp} from './MaskTypes';
+export type {default as SQFormOption, SQFormOptionValue} from './Option';
+export type {default as Mask} from './MaskTypes';

--- a/stories/SQFormButton.stories.tsx
+++ b/stories/SQFormButton.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import type {Story, Meta} from '@storybook/react';
 import {SQFormButton as SQFormButtonComponent, SQFormTextField} from '../src';
-import type {Props as ButtonProps} from 'components/SQForm/SQFormButton';
+import type {SQFormButtonProps} from 'components/SQForm/SQFormButton';
 import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
 import {createDocsPage} from './utils/createDocsPage';
 
@@ -26,7 +26,7 @@ const defaultArgs = {
 // prevents synthetic event warnings
 const handleClick = (event: React.FormEvent) => event.persist();
 
-export const Default: Story<ButtonProps> = (args) => {
+export const Default: Story<SQFormButtonProps> = (args) => {
   return (
     <SQFormStoryWrapper
       initialValues={{}}
@@ -40,7 +40,7 @@ export const Default: Story<ButtonProps> = (args) => {
 };
 Default.args = defaultArgs;
 
-export const WithTestField: Story<ButtonProps> = (args) => {
+export const WithTestField: Story<SQFormButtonProps> = (args) => {
   return (
     <SQFormStoryWrapper
       initialValues={{testField: ''}}

--- a/stories/SQFormGuidedWorkflow.stories.tsx
+++ b/stories/SQFormGuidedWorkflow.stories.tsx
@@ -15,7 +15,7 @@ import {
 import {Grid, Typography} from '@material-ui/core';
 import type {FormikHelpers} from 'formik';
 import type {
-  Context,
+  SQFormGuidedWorkflowContext,
   SQFormGuidedWorkflowProps,
 } from 'components/SQFormGuidedWorkflow/Types';
 import type {CustomStory} from './types/storyHelperTypes';
@@ -66,7 +66,7 @@ const Template: CustomStory<
         onSubmit: async (
           values: typeof initialValues,
           _formikBag: FormikHelpers<typeof initialValues>,
-          _context: Context<typeof initialValues>
+          _context: SQFormGuidedWorkflowContext<typeof initialValues>
         ) => {
           await sleep(3000); // Simulate API call to see loading spinner
           if (values.outcome === 'not-interested') {
@@ -130,7 +130,7 @@ const Template: CustomStory<
         onSubmit: async (
           values: typeof initialValues,
           _formikBag: FormikHelpers<typeof initialValues>,
-          context: Context<typeof initialValues>
+          context: SQFormGuidedWorkflowContext<typeof initialValues>
         ) => {
           console.log(values);
           console.log(context);
@@ -178,7 +178,7 @@ const Template: CustomStory<
         onSubmit: async (
           values: typeof initialValues,
           _formikBag: FormikHelpers<typeof initialValues>,
-          context: Context<typeof initialValues>
+          context: SQFormGuidedWorkflowContext<typeof initialValues>
         ) => {
           console.log(values);
           console.log(context);

--- a/stories/SQFormMaskedReadOnlyField.stories.tsx
+++ b/stories/SQFormMaskedReadOnlyField.stories.tsx
@@ -6,19 +6,19 @@ import {
   MASKS,
   SQFormMaskedReadOnlyField as SQFormMaskedReadOnlyFieldComponent,
 } from '../src';
-import type { maskProp } from 'types';
-import type { SQFormMaskedReadOnlyFieldProps } from '../src/components/SQForm/SQFormMaskedReadOnlyField';
+import type {Mask} from 'types';
+import type {SQFormMaskedReadOnlyFieldProps} from '../src/components/SQForm/SQFormMaskedReadOnlyField';
 import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
 import {createDocsPage} from './utils/createDocsPage';
 import getSizeProp from './utils/getSizeProp';
 
 type SQFormMaskedReadOnlyFieldStory = CustomStory<
   SQFormMaskedReadOnlyFieldProps & {
-    exampleMasks: maskProp;
+    exampleMasks: Mask;
   }
-> 
+>;
 
-const meta: Meta ={ 
+const meta: Meta = {
   title: 'Components/SQFormMaskedReadOnlyField',
   component: SQFormMaskedReadOnlyFieldComponent,
   argTypes: {
@@ -56,7 +56,6 @@ const Template: SQFormMaskedReadOnlyFieldStory = (args) => {
   );
 };
 
-
 export const Default = Template.bind({});
 Default.storyName = 'SQFormMaskedTextField';
 Default.args = defaultArgs;
@@ -73,4 +72,3 @@ Default.argTypes = {
 };
 
 export default meta;
-

--- a/stories/SQFormMaskedTextField.stories.tsx
+++ b/stories/SQFormMaskedTextField.stories.tsx
@@ -12,7 +12,7 @@ import type {Story} from '@storybook/react';
 import type {SQFormMaskedTextFieldProps} from 'components/SQForm/SQFormMaskedTextField';
 import type {GridSizeOptions} from './types/storyHelperTypes';
 import type {AnySchema} from 'yup';
-import type {maskProp} from 'types';
+import type {Mask} from 'types';
 
 export default {
   title: 'Components/SQFormMaskedTextField',
@@ -34,7 +34,7 @@ type MaskedTextFieldStoryType = Story<
     size?: GridSizeOptions;
     sqFormProps?: SQFormStoryWrapperProps;
     schema: Record<string, AnySchema>;
-    exampleMasks: maskProp;
+    exampleMasks: Mask;
   }
 >;
 


### PR DESCRIPTION
Renamed some of the types that were poorly named like "Props" or
"HeaderProps" to things that are more descriptive, less likely have to
collisions, and are more easily identifiable.

✅ Closes: #627