### PR TITLE
refactor: 💡 Actually export TS types for consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,21 @@ For **BREAKING CHANGES** Type a brief description of the breaking change when as
 
 ## Consuming
 
-- `> npm install @selectquotelabs/sqform`
+This is a Typescript library and therefore relies on Typescript types from libraries other than this one. The libraries who's types SQForm relies on are marked as a [peer dependency](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#peerdependencies) if the library is also required for non-type imports. Otherwise, they're marked as an [optional dependency](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#optionaldependencies).
+
+By default in NPM v7 and above peer dependencies will be installed automatically. You can check your npm version using `npm --version` to determine the version you are using. If your version is not at least v7 you must install the peer dependencies manually.
+
+Optional dependencies are always installed but can be omitted by using `npm install --no-optional` when installing this package.
+
+- Using NPM v7 or greater
+  - `> npm install @selectquotelabs/sqform`
+
+- Using NPM v6 and below
+  - `> npm install @selectquotelabs/sqform`
+  - Install peer dependencies manually
+
+- To omit optional dependencies
+  - `> npm install @selectquotelabs/sqform --no-optional`
 
 ## Breaking Changes
 
@@ -43,7 +57,6 @@ For **BREAKING CHANGES** Type a brief description of the breaking change when as
 
 #### SQFormGuidedWorkflow changes
  - Removed TaskModule properties: `isPanelExpanded` and `expandPanel`
-
 
  - In SQForm v`[Typescript Version]` `actionButton` was renamed to `actions` as part of the taskModule definitions. Functionality remains the same.
 

--- a/notes/SQForm.md
+++ b/notes/SQForm.md
@@ -48,11 +48,11 @@ The `helperText` prop defaults to an empty space it is always present in the DOM
 
 **SQFormAutocomplete**
 
-As shown in the component prop-types, the `children` of this component must be an `Array` of objects. Each object must have the shape of `{label: String, value: String | Number}`.
+As shown in the component props, the `children` of this component must be an `Array` of objects. Each object must have the shape of `{label: String, value: String | Number}`.
 
 **SQFormDropdown**
 
-As shown in the component prop-types, the `children` of this component must be an `Array` of objects. Each object must have the shape of `{label: String, value: String | Number}`.
+As shown in the component props, the `children` of this component must be an `Array` of objects. Each object must have the shape of `{label: String, value: String | Number}`.
 
 If you want an empty option in the dropdown list options, set the `displayEmpty` prop to `true`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6616,10 +6616,10 @@
       }
     },
     "@types/react-text-mask": {
-      "version": "5.4.9",
-      "resolved": "https://registry.npmjs.org/@types/react-text-mask/-/react-text-mask-5.4.9.tgz",
-      "integrity": "sha512-y7XGGo4EkT1yoEocDF+YSIukP4iq8XwXJr9+gbzi18yHK6ALW95JOIM8XwF3oAzquNDrtcmEvyqXJETFhXdUHw==",
-      "dev": true,
+      "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/@types/react-text-mask/-/react-text-mask-5.4.11.tgz",
+      "integrity": "sha512-DIJ3/dS4jd7NK3lEgsOwcgpp+ZlVrNJEiUDRayZRE/PNMbV/nLWmOKGdL0BUS29hnx0CDgITgPudKx0BgbF5fA==",
+      "optional": true,
       "requires": {
         "@types/react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -80,10 +80,8 @@
     "@tippy.js/react": "^3.1.1",
     "ag-grid-community": "^25.2.1",
     "ag-grid-react": "^25.2.0",
-    "formik": "^2.2.9",
     "lodash.isequal": "^4.5.0",
     "moment": "^2.29.1",
-    "prop-types": "^15.7.2",
     "react-datepicker": "^2.13.0",
     "react-text-mask": "^5.4.3",
     "react-weekly-schedule": "0.0.0-development",
@@ -98,9 +96,13 @@
     "@material-ui/icons": "^4.5.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
     "@material-ui/pickers": "^4.0.0-alpha.12",
+    "formik": "^2.2.9",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "yup": "^0.32.9"
+  },
+  "optionalDependencies": {
+    "@types/react-text-mask": "^5.4.11"
   },
   "devDependencies": {
     "@babel/core": "^7.11.4",
@@ -138,7 +140,6 @@
     "@types/lodash.isequal": "^4.5.5",
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.4",
-    "@types/react-text-mask": "^5.4.9",
     "@types/react-window": "^1.8.5",
     "@types/testing-library__jest-dom": "^5.9.5",
     "@types/yup": "^0.29.11",

--- a/src/components/SQForm/SQForm.tsx
+++ b/src/components/SQForm/SQForm.tsx
@@ -14,7 +14,7 @@ setLocale({
   },
 });
 
-interface SQFormProps<Values extends Record<string, unknown>> {
+export interface SQFormProps<Values extends Record<string, unknown>> {
   /** Form Input(s) */
   children: React.ReactNode;
   /** Bool to pass through to Formik. https://formik.org/docs/api/formik#enablereinitialize-boolean */

--- a/src/components/SQForm/SQFormAsyncAutocomplete.tsx
+++ b/src/components/SQForm/SQFormAsyncAutocomplete.tsx
@@ -10,7 +10,7 @@ import {Typography} from '@material-ui/core';
 import {getIn, useField, useFormikContext} from 'formik';
 import {usePrevious} from '@selectquotelabs/sqhooks';
 import {useForm} from './useForm';
-import type {SQFormOption} from 'types';
+import type {SQFormOption} from '../../types';
 import {
   ListboxVirtualizedComponentProps,
   OuterElementContextInterface,

--- a/src/components/SQForm/SQFormAutocomplete.tsx
+++ b/src/components/SQForm/SQFormAutocomplete.tsx
@@ -13,7 +13,7 @@ import {VariableSizeList} from 'react-window';
 import type {ListChildComponentProps} from 'react-window';
 import {getIn, useField, useFormikContext} from 'formik';
 import {usePrevious} from '@selectquotelabs/sqhooks';
-import type {BaseFieldProps, SQFormOption} from 'types';
+import type {BaseFieldProps, SQFormOption} from '../../types';
 import {useForm} from './useForm';
 
 export interface SQFormAutocompleteProps extends BaseFieldProps {

--- a/src/components/SQForm/SQFormCheckbox.tsx
+++ b/src/components/SQForm/SQFormCheckbox.tsx
@@ -3,11 +3,11 @@ import {Checkbox} from '@material-ui/core';
 import type {CheckboxProps} from '@material-ui/core';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Grid from '@material-ui/core/Grid';
-import type {BaseFieldProps} from 'types';
+import type {BaseFieldProps} from '../../types';
 
 import {useForm} from './useForm';
 
-interface SQFormCheckboxProps extends BaseFieldProps {
+export interface SQFormCheckboxProps extends BaseFieldProps {
   /** Disabled state of the checkbox */
   isDisabled?: boolean;
   /** Custom onChange event callback */

--- a/src/components/SQForm/SQFormCheckboxGroupItem.tsx
+++ b/src/components/SQForm/SQFormCheckboxGroupItem.tsx
@@ -4,7 +4,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import type {CheckboxProps} from '@material-ui/core';
 import {makeStyles} from '@material-ui/core/styles';
 import {useForm} from './useForm';
-import type {SQFormOption} from 'types';
+import type {SQFormOption} from '../../types';
 
 const useStyles = makeStyles((theme) => ({
   checkboxGroupItem: {
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-interface SQFormCheckboxGroupItemProps {
+export interface SQFormCheckboxGroupItemProps {
   /** The name of the group this checkbox is a part of */
   groupName: string;
   /** Label for the checkbox */

--- a/src/components/SQForm/SQFormDatePicker.tsx
+++ b/src/components/SQForm/SQFormDatePicker.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import moment from 'moment';
+import type {Moment} from 'moment';
 import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
 import {DatePicker} from '@material-ui/pickers';
 import type {BaseDatePickerProps, DatePickerProps} from '@material-ui/pickers';
 import {makeStyles, ClickAwayListener} from '@material-ui/core';
 import type {InputBaseComponentProps} from '@material-ui/core';
-import type {BaseFieldProps} from 'types';
+import type {BaseFieldProps} from '../../types';
 import {useForm} from './useForm';
 
 const useStyles = makeStyles(() => ({
@@ -30,14 +30,14 @@ export interface SQFormDatePickerProps extends BaseFieldProps {
   /** Custom onBlur event callback */
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
   /** Custom onChange event callback */
-  onChange?: (date: moment.Moment | null) => void;
+  onChange?: (date: Moment | null) => void;
   /** Disable specific date(s) (day: DateIOType) => boolean
    * This is a predicate function called for every day of the month
    * Return true to disable that day or false to enable that day
    */
   setDisabledDate?: (day: unknown) => boolean;
   /** Any valid prop for material ui datepicker child component - https://material-ui.com/components/pickers/  */
-  muiFieldProps?: BaseDatePickerProps<moment.Moment>;
+  muiFieldProps?: BaseDatePickerProps<Moment>;
   /** Any valid prop for MUI input field - https://material-ui.com/api/text-field/ & https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attributes */
   muiTextInputProps?: InputBaseComponentProps;
   /** Props provided to the Input component. Most commonly used for adornments. */
@@ -67,12 +67,12 @@ function SQFormDatePicker({
     formikField: {field, helpers},
     fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {handleBlur, HelperTextComponent},
-  } = useForm<moment.Moment | null, moment.Moment | null>({
+  } = useForm<Moment | null, Moment | null>({
     name,
     onBlur,
   });
 
-  const handleChange = (date: moment.Moment | null) => {
+  const handleChange = (date: Moment | null) => {
     helpers.setValue(date);
     onChange && onChange(date);
   };

--- a/src/components/SQForm/SQFormDatePickerWithCalendarInputOnly.tsx
+++ b/src/components/SQForm/SQFormDatePickerWithCalendarInputOnly.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import ClearIcon from '@material-ui/icons/HighlightOff';
 import {useFormikContext} from 'formik';
+import type {Moment} from 'moment';
 import {IconButton, makeStyles} from '@material-ui/core';
 import SQFormDatePicker, {SQFormDatePickerProps} from './SQFormDatePicker';
 import {useForm} from './useForm';
-import type {BaseFieldProps} from 'types';
+import type {BaseFieldProps} from '../../types';
 
 export interface SQFormDatePickerWithCalendarInputOnlyProps
   extends BaseFieldProps {
@@ -65,14 +66,13 @@ function SQFormDatePickerWithCalendarInputOnly({
   });
   const clearButtonClasses = useClearButtonStyles();
   const calendarButtonClasses = useCalendarButtonStyles();
-  const {values, setFieldValue} =
-    useFormikContext<{[name: string]: moment.Moment}>();
+  const {values, setFieldValue} = useFormikContext<{[name: string]: Moment}>();
 
   const clearField = () => {
     setFieldValue(name, '');
   };
 
-  const handleChange = (date: moment.Moment | null) => {
+  const handleChange = (date: Moment | null) => {
     helpers.setValue(date);
     onChange && onChange(date);
   };

--- a/src/components/SQForm/SQFormDateTimePicker.tsx
+++ b/src/components/SQForm/SQFormDateTimePicker.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import moment from 'moment';
+import type {Moment} from 'moment';
 import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
 import {DateTimePicker} from '@material-ui/pickers';
 import type {BaseDateTimePickerProps} from '@material-ui/pickers';
 import {ClickAwayListener, makeStyles} from '@material-ui/core';
 import {useForm} from './useForm';
-import type {BaseFieldProps} from 'types';
+import type {BaseFieldProps} from '../../types';
 import type {ParsableDate} from '@material-ui/pickers/constants/prop-types';
 
 export interface SQFormDateTimePickerProps extends BaseFieldProps {
@@ -17,9 +17,9 @@ export interface SQFormDateTimePickerProps extends BaseFieldProps {
   /** Custom onBlur event callback */
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
   /** Custom onChange event callback */
-  onChange?: (date: moment.Moment | null) => void;
+  onChange?: (date: Moment | null) => void;
   /** Any valid prop for material ui datetimepicker child component - https://material-ui.com/components/pickers/  */
-  muiFieldProps?: BaseDateTimePickerProps<moment.Moment>;
+  muiFieldProps?: BaseDateTimePickerProps<Moment>;
 }
 
 const useStyles = makeStyles(() => ({
@@ -47,7 +47,7 @@ function SQFormDateTimePicker({
     formikField: {field, helpers},
     fieldState: {isFieldError, isFieldRequired},
     fieldHelpers: {handleBlur, HelperTextComponent},
-  } = useForm<moment.Moment | null, unknown>({
+  } = useForm<Moment | null, unknown>({
     name,
     onBlur,
   });
@@ -64,10 +64,10 @@ function SQFormDateTimePicker({
   const classes = useStyles();
 
   // An empty string will not reset the DatePicker so we have to pass null
-  const value: ParsableDate<moment.Moment> | null =
-    (field.value as ParsableDate<moment.Moment>) ?? null;
+  const value: ParsableDate<Moment> | null =
+    (field.value as ParsableDate<Moment>) ?? null;
 
-  const handleChange = (date: moment.Moment | null): void => {
+  const handleChange = (date: Moment | null): void => {
     helpers.setValue(date);
     onChange && onChange(date);
   };

--- a/src/components/SQForm/SQFormDropdown.tsx
+++ b/src/components/SQForm/SQFormDropdown.tsx
@@ -16,7 +16,7 @@ import {
   getUndefinedValueWarning,
 } from '../../utils/consoleWarnings';
 import {EMPTY_LABEL} from '../../utils/constants';
-import type {BaseFieldProps, SQFormOption} from 'types';
+import type {BaseFieldProps, SQFormOption} from '../../types';
 
 export interface SQFormDropdownProps extends BaseFieldProps {
   /** Dropdown options to select from */

--- a/src/components/SQForm/SQFormHelperText.tsx
+++ b/src/components/SQForm/SQFormHelperText.tsx
@@ -34,7 +34,7 @@ const helperStateMap = {
   valid: 'valid',
 };
 
-interface SQFormHelperTextProps {
+export interface SQFormHelperTextProps {
   isFailedState?: boolean;
   errorText?: string;
   failText?: string;

--- a/src/components/SQForm/SQFormInclusionList.tsx
+++ b/src/components/SQForm/SQFormInclusionList.tsx
@@ -4,7 +4,7 @@ import type {GridProps} from '@material-ui/core';
 import {useFormikContext, FieldArray, FieldArrayRenderProps} from 'formik';
 import SQFormInclusionListItem from './SQFormInclusionListItem';
 import type {SQFormInclusionListItemProps} from './SQFormInclusionListItem';
-import type {SQFormOption} from 'types';
+import type {SQFormOption} from '../../types';
 
 export interface SQFormInclusionListProps {
   /** the `name` must match the name of the desired array in `initialValues` */

--- a/src/components/SQForm/SQFormInclusionListItem.tsx
+++ b/src/components/SQForm/SQFormInclusionListItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Grid from '@material-ui/core/Grid';
-import type {BaseFieldProps} from 'types';
+import type {BaseFieldProps} from '../../types';
 
 import {useForm} from './useForm';
 

--- a/src/components/SQForm/SQFormMaskedReadOnlyField.tsx
+++ b/src/components/SQForm/SQFormMaskedReadOnlyField.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import MaskedInput from 'react-text-mask';
-import type {Mask} from 'types';
+import type {Mask} from '../../types';
 import SQFormReadOnlyField from './SQFormReadOnlyField';
 import type {SQFormReadOnlyFieldProps} from './SQFormReadOnlyField';
 

--- a/src/components/SQForm/SQFormMaskedTextField.tsx
+++ b/src/components/SQForm/SQFormMaskedTextField.tsx
@@ -1,7 +1,7 @@
 import {useFormikContext} from 'formik';
 import React from 'react';
 import MaskedInput from 'react-text-mask';
-import type {Mask} from 'types';
+import type {Mask} from '../../types';
 import SQFormTextField from './SQFormTextField';
 import type {SQFormTextFieldProps} from './SQFormTextField';
 

--- a/src/components/SQForm/SQFormMultiSelect.tsx
+++ b/src/components/SQForm/SQFormMultiSelect.tsx
@@ -21,7 +21,7 @@ import {
   getUndefinedChildrenWarning,
   getUndefinedValueWarning,
 } from '../../utils/consoleWarnings';
-import type {BaseFieldProps, SQFormOption} from 'types';
+import type {BaseFieldProps, SQFormOption} from '../../types';
 
 export interface SQFormMultiSelectProps extends BaseFieldProps {
   /** Multiselect options to select from */

--- a/src/components/SQForm/SQFormMultiValue.tsx
+++ b/src/components/SQForm/SQFormMultiValue.tsx
@@ -9,7 +9,7 @@ import type {ListChildComponentProps} from 'react-window';
 import {useField, useFormikContext} from 'formik';
 import {usePrevious} from '@selectquotelabs/sqhooks';
 import {useForm} from './useForm';
-import type {BaseFieldProps, SQFormOption} from 'types';
+import type {BaseFieldProps, SQFormOption} from '../../types';
 import type {
   OuterElementContextInterface,
   OuterElementTypeProps,

--- a/src/components/SQForm/SQFormRadioButtonGroupItem.tsx
+++ b/src/components/SQForm/SQFormRadioButtonGroupItem.tsx
@@ -4,7 +4,7 @@ import {makeStyles} from '@material-ui/core/styles';
 import {FormControlLabel} from '@material-ui/core';
 import type {RadioProps} from '@material-ui/core';
 
-interface SQFormRadioButtonGroupItemProps {
+export interface SQFormRadioButtonGroupItemProps {
   /** Value of the radio button */
   value: string | boolean | number;
   /** Label for the radio button */

--- a/src/components/SQForm/SQFormReadOnlyField.tsx
+++ b/src/components/SQForm/SQFormReadOnlyField.tsx
@@ -3,7 +3,7 @@ import {Grid} from '@material-ui/core';
 import TextField from '@material-ui/core/TextField';
 import type {TextFieldProps} from '@material-ui/core';
 import {useForm} from './useForm';
-import type {BaseFieldProps} from 'types';
+import type {BaseFieldProps} from '../../types';
 import {toKebabCase} from '../../utils';
 
 export interface SQFormReadOnlyFieldProps extends BaseFieldProps {

--- a/src/components/SQForm/SQFormTextField.tsx
+++ b/src/components/SQForm/SQFormTextField.tsx
@@ -3,7 +3,8 @@ import {TextField} from '@material-ui/core';
 import type {TextFieldProps, InputProps} from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import type {BaseFieldProps, Mask} from 'types';
+import type Mask from '../../types/MaskTypes';
+import type {BaseFieldProps} from '../../types';
 
 import {useForm} from './useForm';
 import {toKebabCase} from '../../utils';

--- a/src/components/SQForm/SQFormTextarea.tsx
+++ b/src/components/SQForm/SQFormTextarea.tsx
@@ -5,7 +5,7 @@ import {useFormikContext} from 'formik';
 import type {FormikProps} from 'formik';
 import {useForm} from './useForm';
 import type {TextFieldProps} from '@material-ui/core';
-import type {BaseFieldProps} from 'types';
+import type {BaseFieldProps} from '../../types';
 import {toKebabCase} from '../../utils';
 
 export interface SQFormTextareaProps extends BaseFieldProps {

--- a/src/components/SQFormDialog/SQFormDialog.tsx
+++ b/src/components/SQFormDialog/SQFormDialog.tsx
@@ -3,6 +3,7 @@ import {Formik} from 'formik';
 import type {FormikHelpers} from 'formik';
 import type {DialogProps, GridProps} from '@material-ui/core';
 import * as Yup from 'yup';
+import type {AnySchema} from 'yup';
 import SQFormDialogInner from './SQFormDialogInner';
 import {useInitialRequiredErrors} from '../../hooks/useInitialRequiredErrors';
 
@@ -51,7 +52,7 @@ export interface SQFormDialogProps<Values> {
    * */
   validationSchema: Record<
     keyof Values,
-    Yup.AnySchema<Values[keyof Values] | null | undefined>
+    AnySchema<Values[keyof Values] | null | undefined>
   >;
 }
 

--- a/src/components/SQFormDialogStepper/SQFormDialogStepper.tsx
+++ b/src/components/SQFormDialogStepper/SQFormDialogStepper.tsx
@@ -19,13 +19,14 @@ import type {
   DialogContentProps,
 } from '@material-ui/core';
 import * as Yup from 'yup';
+import type {AnySchema} from 'yup';
 import {Form, Formik, useFormikContext} from 'formik';
 import type {FormikHelpers} from 'formik';
 import {RoundedButton} from 'scplus-shared-components';
 import LoadingSpinner from '../LoadingSpinner';
 import type {TransitionProps} from '@material-ui/core/transitions';
 
-interface SQFormDialogStepProps<Values> {
+export interface SQFormDialogStepProps<Values> {
   /** The content to be rendered in the step body. */
   children?: JSX.Element | Array<JSX.Element>;
   /** Should the loading spinner be shown */
@@ -35,7 +36,7 @@ interface SQFormDialogStepProps<Values> {
   /** The label to display in the stepper */
   label?: string;
   /** Validation schema for this step */
-  validationSchema?: Record<keyof Values, Yup.AnySchema>;
+  validationSchema?: Record<keyof Values, AnySchema>;
 }
 
 export function SQFormDialogStep<Values extends Record<string, unknown>>({

--- a/src/components/SQFormScrollableCard/SQFormScrollableCard.tsx
+++ b/src/components/SQFormScrollableCard/SQFormScrollableCard.tsx
@@ -9,6 +9,7 @@ import {
   makeStyles,
   TypographyVariant,
 } from '@material-ui/core';
+import type {AnySchema} from 'yup';
 import type {GridProps} from '@material-ui/core';
 import {Formik, Form, FormikHelpers} from 'formik';
 import {useDebouncedCallback} from 'use-debounce';
@@ -71,7 +72,7 @@ export interface SQFormScrollableCardProps<Values> {
    * */
   validationSchema?: Record<
     keyof Values,
-    Yup.AnySchema<Values[keyof Values] | null | undefined>
+    AnySchema<Values[keyof Values] | null | undefined>
   >;
   /** Boolean used to determine if title/header is enabled or disabled */
   isHeaderDisabled?: boolean;

--- a/src/components/SQFormScrollableCardsMenuWrapper/SQFormScrollableCardsMenuWrapper.tsx
+++ b/src/components/SQFormScrollableCardsMenuWrapper/SQFormScrollableCardsMenuWrapper.tsx
@@ -50,7 +50,7 @@ function getSelectedComponent(
   return children;
 }
 
-interface SQFormScrollableCardsMenuWrapperProps {
+export interface SQFormScrollableCardsMenuWrapperProps {
   /** At least one instance of SQFormScrollableCard where each has
    * prop `isHeaderDisabled` === true
    * AND

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,3 +39,113 @@ export {default as SQFormScrollableCard} from './components/SQFormScrollableCard
 export {default as SQFormScrollableCardsMenuWrapper} from './components/SQFormScrollableCardsMenuWrapper';
 export {default as SQFormGuidedWorkflow} from './components/SQFormGuidedWorkflow';
 export {default as SQFormMultiValue} from './components/SQForm/SQFormMultiValue';
+
+// Component Types
+// NOTE: Unfortunately TS doesn't support `export type *`
+export type {SQFormDialogProps} from './components/SQFormDialog/SQFormDialog';
+export type {SQFormProps} from './components/SQForm/SQForm';
+export type {SQFormAsyncAutocompleteProps} from './components/SQForm/SQFormAsyncAutocomplete';
+export type {SQFormAutocompleteProps} from './components/SQForm/SQFormAutocomplete';
+export type {SQFormButtonProps} from './components/SQForm/SQFormButton';
+export type {SQFormCheckboxProps} from './components/SQForm/SQFormCheckbox';
+export type {SQFormInclusionListProps} from './components/SQForm/SQFormInclusionList';
+export type {SQFormInclusionListItemProps} from './components/SQForm/SQFormInclusionListItem';
+export type {SQFormDatePickerProps} from './components/SQForm/SQFormDatePicker';
+export type {SQFormDateTimePickerProps} from './components/SQForm/SQFormDateTimePicker';
+export type {SQFormDatePickerWithCalendarInputOnlyProps} from './components/SQForm/SQFormDatePickerWithCalendarInputOnly';
+export type {SQFormRadioButtonGroupItemProps} from './components/SQForm/SQFormRadioButtonGroupItem';
+export type {SQFormRadioButtonGroupProps} from './components/SQForm/SQFormRadioButtonGroup';
+export type {SQFormCheckboxGroupProps} from './components/SQForm/SQFormCheckboxGroup';
+export type {SQFormCheckboxGroupItemProps} from './components/SQForm/SQFormCheckboxGroupItem';
+export type {
+  SQFormDialogStepperProps,
+  SQFormDialogStepProps,
+} from './components/SQFormDialogStepper/SQFormDialogStepper';
+export type {SQFormDropdownProps} from './components/SQForm/SQFormDropdown';
+export type {SQFormReadOnlyFieldProps} from './components/SQForm/SQFormReadOnlyField';
+export type {SQFormResetButtonWithConfirmationProps} from './components/SQForm/SQFormResetButtonWithConfirmation';
+export type {SQFormResetInitialValuesButtonProps} from './components/SQForm/SQFormResetInitialValuesButton';
+export type {SQFormTextareaProps} from './components/SQForm/SQFormTextarea';
+export type {SQFormTextFieldProps} from './components/SQForm/SQFormTextField';
+export type {SQFormMultiSelectProps} from './components/SQForm/SQFormMultiSelect';
+export type {SQFormMaskedTextFieldProps} from './components/SQForm/SQFormMaskedTextField';
+export type {SQFormMaskedReadOnlyFieldProps} from './components/SQForm/SQFormMaskedReadOnlyField';
+export type {SQFormHelperTextProps} from './components/SQForm/SQFormHelperText';
+export type {SQFormScrollableCardProps} from './components/SQFormScrollableCard/SQFormScrollableCard';
+export type {SQFormScrollableCardsMenuWrapperProps} from './components/SQFormScrollableCardsMenuWrapper/SQFormScrollableCardsMenuWrapper';
+export type {SQFormMultiValueProps} from './components/SQForm/SQFormMultiValue';
+export type {
+  SQFormGuidedWorkflowProps,
+  SQFormGuidedWorkflowHeaderProps,
+  SQFormGuidedWorkflowAdditionalInformationProps,
+  SQFormGuidedWorkflowAgentScriptProps,
+  SQFormGuidedWorkflowOutcomeProps,
+  SQFormGuidedWorkflowDataProps,
+  SQFormGuidedWorkflowTaskModuleProps,
+  SQFormGuidedWorkflowContext,
+} from './components/SQFormGuidedWorkflow/Types';
+
+// Other Types
+// export type {BaseFieldProps, SQFormOption, SQFormOptionValue, Mask} from './types';
+export type {default as BaseFieldProps} from './types/BaseFieldProps';
+export type {default as SQFormOption, SQFormOptionValue} from './types/Option';
+export type {default as Mask} from './types/MaskTypes';
+
+/*
+// 3rd part types SQForm relies on
+export type {
+  FormikValues,
+  FormikHelpers,
+  FormikConfig,
+  FieldArrayRenderProps
+} from 'formik';
+
+export type {
+  DialogProps,
+  GridProps,
+  GridSize,
+  CheckboxProps,
+  InputBaseComponentProps,
+  RadioProps,
+  RadioGroupProps,
+  DialogContentProps,
+  TextFieldProps,
+  InputProps,
+  TooltipProps,
+  SelectProps as SelectProps$1,
+  TypographyVariant
+} from '@material-ui/core';
+
+export type {
+  AutocompleteProps
+} from '@material-ui/lab';
+
+export type { AutocompleteChangeReason } from '@material-ui/lab/Autocomplete';
+
+
+export type {
+  AnySchema,
+} from 'yup';
+
+export type {
+  ObjectShape
+} from 'yup/lib/object'
+
+export type {
+  Moment
+} from 'moment';
+
+export type {
+  BaseDatePickerProps,
+  DatePickerProps,
+  BaseDateTimePickerProps
+} from '@material-ui/pickers';
+
+export type {
+  SelectProps
+} from '@material-ui/core/Select';
+
+export type {
+  maskArray
+} from 'react-text-mask';
+*/

--- a/src/types/MaskTypes.ts
+++ b/src/types/MaskTypes.ts
@@ -1,4 +1,4 @@
-import type {maskArray} from 'react-text-mask';
-type Mask = maskArray | ((value: string) => maskArray);
+import type {Mask as MaskArray} from 'react-text-mask';
+type Mask = MaskArray | ((value: string) => MaskArray);
 
 export default Mask;

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import type {Moment} from 'moment';
 
 export const DATE_TIME_FORMATS = {
   DATABASE_FORMAT: 'YYYY-MM-DD HH:mm:ss.SSS', // Possibly not needed
@@ -30,7 +31,7 @@ export const DATE_TIME_FORMATS = {
  * @returns {string} The date/time as a utc ISO string
  */
 export function getDateWithoutTimezone(
-  dateTime: moment.Moment | string,
+  dateTime: Moment | string,
   fromFormat: string
 ): string {
   if (!dateTime) {
@@ -52,9 +53,9 @@ export function getDateWithoutTimezone(
  * @returns {Moment} A Moment object converted to local browser time
  */
 export function applyBrowserTimezoneToDate(
-  dateTime: moment.Moment | string,
+  dateTime: Moment | string,
   fromFormat: string
-): moment.Moment {
+): Moment {
   if (!dateTime) {
     dateTime = moment();
   }
@@ -75,7 +76,7 @@ export function applyBrowserTimezoneToDate(
  * @returns {string} The date/time as a utc ISO string
  */
 export function clientMomentToSpecialServerFormat(
-  dateTime: moment.Moment | string,
+  dateTime: Moment | string,
   toFormat: string,
   fromFormat: string
 ): string {
@@ -96,9 +97,7 @@ export function clientMomentToSpecialServerFormat(
  * @param {string} date - the string date time to convert.
  * @returns {Moment} - a Moment date time object.
  */
-export function getDateAsMomentIfValid(
-  date: string
-): moment.Moment | undefined {
+export function getDateAsMomentIfValid(date: string): Moment | undefined {
   if (!date) {
     return undefined;
   }

--- a/src/utils/masks.ts
+++ b/src/utils/masks.ts
@@ -1,8 +1,8 @@
-import type {maskArray} from 'react-text-mask';
+import type {Mask as MaskArray} from 'react-text-mask';
 import createNumberMask from 'text-mask-addons/dist/createNumberMask';
 import emailMask from 'text-mask-addons/dist/emailMask';
 
-const zipMask = (userInput: string): maskArray => {
+const zipMask = (userInput: string): MaskArray => {
   const numbers = userInput.match(/\d/g);
   const numberLength = numbers ? numbers.join('').length : 0;
 

--- a/stories/SQFormAsyncAutocomplete.stories.tsx
+++ b/stories/SQFormAsyncAutocomplete.stories.tsx
@@ -1,6 +1,7 @@
 import {action} from '@storybook/addon-actions';
 import React from 'react';
 import * as Yup from 'yup';
+import {AnySchema} from 'yup';
 
 import {SQFormAsyncAutocomplete} from '../src';
 import getSizeProp from './utils/getSizeProp';
@@ -19,7 +20,7 @@ type SQFormAsyncAutocompleteStory = Story<
   Omit<SQFormAsyncAutocompleteProps, 'size'> & {
     size?: GridSizeOptions;
     sqFormProps?: FormProps;
-    schema: Record<string, Yup.AnySchema>;
+    schema: Record<string, AnySchema>;
   }
 >;
 

--- a/stories/SQFormDatePicker.stories.tsx
+++ b/stories/SQFormDatePicker.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as Yup from 'yup';
+import type {AnySchema} from 'yup';
 import {SQFormDatePicker as SQFormDatePickerComponent} from '../src';
 import {createDocsPage} from './utils/createDocsPage';
 import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
@@ -15,7 +16,7 @@ export type FormProps = {
 export type SQFormDatePickerStory = Story<
   Omit<SQFormDatePickerProps, 'label' | 'name'> & {
     sqFormProps?: FormProps;
-    schema: Record<string, Yup.AnySchema>;
+    schema: Record<string, AnySchema>;
   }
 >;
 

--- a/stories/SQFormDatePickerWithCalendarInputOnly.stories.tsx
+++ b/stories/SQFormDatePickerWithCalendarInputOnly.stories.tsx
@@ -1,11 +1,11 @@
-import { Meta } from '@storybook/react';
-import type { SQFormDatePickerWithCalendarInputOnlyProps } from 'components/SQForm/SQFormDatePickerWithCalendarInputOnly';
-import moment from 'moment';
+import {Meta} from '@storybook/react';
+import type {SQFormDatePickerWithCalendarInputOnlyProps} from 'components/SQForm/SQFormDatePickerWithCalendarInputOnly';
+import type {Moment} from 'moment';
 import React from 'react';
 import * as Yup from 'yup';
 import {SQFormDatePickerWithCalendarInputOnly as SQFormDatePickerWithCalendarInputOnlyComponent} from '../src';
 import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
-import type { CustomStory } from './types/storyHelperTypes';
+import type {CustomStory} from './types/storyHelperTypes';
 import {createDocsPage} from './utils/createDocsPage';
 import getSizeProp from './utils/getSizeProp';
 
@@ -15,29 +15,29 @@ const meta: Meta = {
   argTypes: {
     onBlur: {action: 'blurred', table: {disable: true}},
     onChange: {action: 'changed', table: {disable: true}},
-    name: {table: {disable: true}}
+    name: {table: {disable: true}},
   },
   parameters: {
-    docs: {page: createDocsPage()}
-  }
+    docs: {page: createDocsPage()},
+  },
 };
 
 const MOCK_INITIAL_STATE = {
-  date: '12/01/1990'
+  date: '12/01/1990',
 };
 
 const basicSchema = {
-  date: Yup.date()
-    .required()
-    .typeError('Invalid date')
+  date: Yup.date().required().typeError('Invalid date'),
 };
 
 const defaultArgs = {
   label: 'Date',
-  name: 'date'
+  name: 'date',
 };
 
-const Template: CustomStory<SQFormDatePickerWithCalendarInputOnlyProps> = args => {
+const Template: CustomStory<SQFormDatePickerWithCalendarInputOnlyProps> = (
+  args
+) => {
   return (
     <SQFormStoryWrapper
       initialValues={MOCK_INITIAL_STATE}
@@ -58,25 +58,25 @@ export const DisableWeekendsDatePicker = Template.bind({});
 DisableWeekendsDatePicker.args = {
   ...defaultArgs,
   setDisabledDate: (date) => {
-    const inputDate = date as moment.Moment;
+    const inputDate = date as Moment;
     if (inputDate.day() === 0 || inputDate.day() === 6) {
       return true;
     }
     return false;
-  }
+  },
 };
 
 export const OnlyEnableFirstDayOfMonthDatePicker = Template.bind({});
 OnlyEnableFirstDayOfMonthDatePicker.args = {
   ...defaultArgs,
-  setDisabledDate: date => {
+  setDisabledDate: (date) => {
     // disable all days EXCEPT first day of the month
-    const inputDate = date as moment.Moment;
+    const inputDate = date as Moment;
     if (inputDate.date() !== 1) {
       return true;
     }
     return false;
-  }
+  },
 };
 
 export default meta;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "jsx": "react",
     "declaration": true,
     "declarationDir": ".dts",
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
   },
   "include": ["./src", "./jest-setup.ts", "./stories"],
   "exclude": ["**/*.test(.ts|.tsx)"]


### PR DESCRIPTION
Actually exporting the TS types for consumers to import should they need
this. This also provided cause for renaming or rearranging imports on
some components.

Please watch the loom if you have questions about why some changes were made: https://www.loom.com/share/d4d8b13173444913bf1669ef9f8d8e76

✅ Closes: #627