### PR TITLE
fix: 🐛 Removing deprecated MUI Dialog prop disable Bg click

### DIFF
--- a/src/components/SQFormDialog/SQFormDialogInner.js
+++ b/src/components/SQFormDialog/SQFormDialogInner.js
@@ -87,9 +87,16 @@ function SQFormDialogInner({
     closeDialog: closeDialogAlert,
   } = useDialog();
 
-  const handleCancel = () => {
+  const handleCancel = (
+    event, // Record<string, unknown>,
+    reason // 'backdropClick' | 'escapeKeyDown' | 'cancelClick'
+  ) => {
+    if (disableBackdropClick && reason === 'backdropClick') {
+      return;
+    }
+
     if (!isDirty) {
-      onClose();
+      onClose(event, reason);
     } else {
       openDialogAlert();
     }
@@ -105,13 +112,13 @@ function SQFormDialogInner({
     return (
       <Grid
         container={true}
-        justify={showSecondaryButton ? 'space-between' : 'flex-end'}
+        justifyContent={showSecondaryButton ? 'space-between' : 'flex-end'}
       >
         {showSecondaryButton && (
           <Grid item={true}>
             <RoundedButton
               title={cancelButtonText}
-              onClick={handleCancel}
+              onClick={(event) => handleCancel(event, 'cancelClick')}
               color="secondary"
               variant="outlined"
             >
@@ -148,11 +155,12 @@ function SQFormDialogInner({
   return (
     <>
       <Dialog
-        disableBackdropClick={disableBackdropClick}
         maxWidth={maxWidth}
         open={isOpen}
         TransitionComponent={Transition}
-        onClose={showSecondaryButton ? handleCancel : undefined}
+        onClose={
+          showSecondaryButton || disableBackdropClick ? handleCancel : undefined
+        }
       >
         <Form>
           <DialogTitle disableTypography={true} classes={titleClasses}>
@@ -177,7 +185,7 @@ function SQFormDialogInner({
               : showSecondaryButton && (
                   <RoundedButton
                     title={cancelButtonText}
-                    onClick={handleCancel}
+                    onClick={(event) => handleCancel(event, 'cancelClick')}
                     color="secondary"
                     variant="outlined"
                   >

--- a/src/components/SQFormDialogStepper/SQFormDialogStepper.js
+++ b/src/components/SQFormDialogStepper/SQFormDialogStepper.js
@@ -173,6 +173,17 @@ export function SQFormDialogStepper({
     );
   }
 
+  const handleClose = (
+    event, // Record<string, unknown>,
+    reason // 'backdropClick' | 'escapeKeyDown' | 'cancelClick'
+  ) => {
+    if (disableBackdropClick && reason === 'backDropClick') {
+      return;
+    }
+
+    onClose(event, reason);
+  };
+
   return (
     <Formik
       {...props}
@@ -187,7 +198,7 @@ export function SQFormDialogStepper({
           disableBackdropClick={disableBackdropClick}
           maxWidth={maxWidth}
           open={isOpen}
-          onClose={onClose}
+          onClose={handleClose}
           fullWidth={fullWidth}
           {...dialogProps}
         >


### PR DESCRIPTION
✅ Closes: #646
We are using a deprecated prop disableBackdropClick. This resolves the SQForm usage, but it is still being used in scplus-shared-components. I will open a task to resolve that. Please watch the loom. This started with me investigating issues on the Typescript branch. Since the issue is not rooted in the TS work, I have fixed it here and will merge it into the TS branch after this is merged. 

https://www.loom.com/share/afd552c8943d4c069ae5c7f1d80a5dd9