### PR TITLE
refactor: 💡 SQForm components now only accept Yup schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,20 +55,40 @@ Optional dependencies are always installed but can be omitted by using `npm inst
 
 ### Version 8
 
+#### SQForm components no longer accept POJO validation schemas
+ - SQForm components now *only* accept validation schema objects that are of type `Yup.AnyObjectSchema`. You can create these types of schema using `Yup.object()`. Supplying any other type of object will have unexpected results and validation will fail to work.
+ - This is an intentional design to facilitate using Yup to create models to be shared between servers and clients.
+
+```jsx
+// ⛔️ Example
+const validationSchema = {
+  friends: Yup.array().required('Required')
+};
+
+// ✅  Example
+// Addition of `Yup.object` wrapping our validation object
+const validationSchema = Yup.object({ 
+  friends: Yup.array().required('Required').min(1, 'Atleast one required')
+});
+
+```
+<em>Note: `Yup.object().shape({})` may fail to provide the correct type and cause issues in Typescript projects. `.shape()` is advised to be used only to extend or modify already existing schemas. `const newSchema = existingSchema.shape({ newKey: ... })`</em>
+
+
 #### Upgraded `Yup` peer dependency version
  - Yup was upgraded from `^0.28.3` to `^0.32.9`, see [Yup's breaking changes](https://github.com/jquense/yup/blob/master/CHANGELOG.md)
    - `array().required()` will no longer consider an empty array missing and required checks will pass.
 
 ```jsx
 // ⛔️ Example
-const validationSchema = {
+const validationSchema = Yup.object({
   friends: Yup.array().required('Required')
-}
+});
 
 // ✅  Example
-const validationSchema = {
+const validationSchema = Yup.object({
   friends: Yup.array().required('Required').min(1, 'Atleast one required')
-}
+});
 ```
 
 #### SQFormDialog changes
@@ -84,7 +104,6 @@ return (
     onClose={closeSQFormDialog}
     title="Title"
     initialValues={{}}
-    validationSchema={{}}
     {/* Missing `onSave`*/}
   >
     {...}
@@ -101,7 +120,6 @@ return (
     onClose={closeSQFormDialog}
     title="Title"
     initialValues={{}}
-    validationSchema={{}}
     onSave={() => {}} /* `onSave` supplied */
     shouldDisplaySaveButton={false} /* Prevents save button from being displayed */
   >
@@ -146,7 +164,7 @@ const taskModules = [
 ```
 
 #### SQForm no longer allows `boolean`s as dropdown options
-In SQForm v8 support for `boolean` valued dropdown options was removed. Material-UI and HTML Select components do not support options with `boolean`s as values and causes type conflicts with our own library. Therefore, if you're upgrading this version and you using `boolean` values options you'll need to take care to update those. Below is our recommended changes.
+- In SQForm v8 support for `boolean` valued dropdown options was removed. Material-UI and HTML Select components do not support options with `boolean`s as values and causes type conflicts with our own library. Therefore, if you're upgrading this version and you using `boolean` values options you'll need to take care to update those. Below is our recommended changes.
 
 ```js
 // ⛔️ Example
@@ -162,7 +180,7 @@ const YES_NO_DROPDOWN_OPTIONS = [
 ]
 ```
 
-Be sure that when you change your dropdown options that you take care to update your submit, onChange, and onBlur handlers such that you're taking into account that the values for the affected forms will no longer be `boolean`s. Using `1` and `0` will still allow for `if(dropdownValue)` to evaluate correctly. However, if you're expecting your values to be passed as booleans outside of any event handlers you'll need to use `Boolean(dropdownValue)`. See an example below of how one might update an SQForm submit handler to comply with this breaking change.
+- Be sure that when you change your dropdown options that you take care to update your submit, onChange, and onBlur handlers such that you're taking into account that the values for the affected forms will no longer be `boolean`s. Using `1` and `0` will still allow for `if(dropdownValue)` to evaluate correctly. However, if you're expecting your values to be passed as booleans outside of any event handlers you'll need to use `Boolean(dropdownValue)`. See an example below of how one might update an SQForm submit handler to comply with this breaking change.
 
 ```js
 const updateSurveyAnswer = (surveyAnswer: boolean) => {
@@ -197,10 +215,11 @@ const handleSubmit = (formValues: FormValues) => {
 });
 ```
 
-Lastly, you'll also need to make sure you update your Yup validation for the affected form fields from `Yup.boolean()` to `Yup.number()` or whatever new value type you're using for your affected dropdown options.
+- Lastly, you'll also need to make sure you update your Yup validation for the affected form fields from `Yup.boolean()` to `Yup.number()` or whatever new value type you're using for your affected dropdown options.
+
 ### Version 7
 
-In SQForm v7, we have removed the SQFormIconButton in favor of the SQFormButton where the text says either "Submit" or "Save". Please replace all occurrences of SQFormIconButton with SQFormButton in the consuming application.
+- In SQForm v7, we have removed the SQFormIconButton in favor of the SQFormButton where the text says either "Submit" or "Save". Please replace all occurrences of SQFormIconButton with SQFormButton in the consuming application.
 
 ### Version 6
 

--- a/src/components/SQForm/SQForm.tsx
+++ b/src/components/SQForm/SQForm.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import Grid from '@material-ui/core/Grid';
+import {setLocale} from 'yup';
+import type {AnyObjectSchema} from 'yup';
 import {Formik, Form} from 'formik';
 import {useDebouncedCallback} from 'use-debounce';
-import {object as YupObject, setLocale} from 'yup';
 import {useInitialRequiredErrors} from '../../hooks/useInitialRequiredErrors';
 import type {GridProps} from '@material-ui/core';
-import type {FormikHelpers, FormikConfig} from 'formik';
-import type {ObjectShape} from 'yup/lib/object';
+import type {FormikHelpers, FormikConfig, FormikValues} from 'formik';
 
 setLocale({
   mixed: {
@@ -14,7 +14,7 @@ setLocale({
   },
 });
 
-export interface SQFormProps<Values extends Record<string, unknown>> {
+export interface SQFormProps<Values extends FormikValues> {
   /** Form Input(s) */
   children: React.ReactNode;
   /** Bool to pass through to Formik. https://formik.org/docs/api/formik#enablereinitialize-boolean */
@@ -36,10 +36,10 @@ export interface SQFormProps<Values extends Record<string, unknown>> {
    * Yup validation schema shape
    * https://jaredpalmer.com/formik/docs/guides/validation#validationschema
    * */
-  validationSchema?: ObjectShape;
+  validationSchema?: AnyObjectSchema;
 }
 
-function SQForm<Values extends Record<string, unknown>>({
+function SQForm<Values extends FormikValues>({
   children,
   enableReinitialize = false,
   initialValues,
@@ -47,12 +47,6 @@ function SQForm<Values extends Record<string, unknown>>({
   onSubmit,
   validationSchema,
 }: SQFormProps<Values>): JSX.Element {
-  const validationYupSchema = React.useMemo(() => {
-    if (!validationSchema) return;
-
-    return YupObject().shape(validationSchema);
-  }, [validationSchema]);
-
   const initialErrors = useInitialRequiredErrors(
     validationSchema,
     initialValues
@@ -80,7 +74,7 @@ function SQForm<Values extends Record<string, unknown>>({
       initialValues={initialValues}
       onSubmit={handleSubmit}
       onReset={handleReset}
-      validationSchema={validationYupSchema}
+      validationSchema={validationSchema}
       validateOnMount={true}
     >
       {(_props) => {

--- a/src/components/SQFormDialog/SQFormDialog.tsx
+++ b/src/components/SQFormDialog/SQFormDialog.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import {Formik} from 'formik';
-import type {FormikHelpers} from 'formik';
+import type {FormikHelpers, FormikValues} from 'formik';
 import type {DialogProps, GridProps} from '@material-ui/core';
-import * as Yup from 'yup';
-import type {AnySchema} from 'yup';
+import type {AnyObjectSchema} from 'yup';
 import SQFormDialogInner from './SQFormDialogInner';
 import {useInitialRequiredErrors} from '../../hooks/useInitialRequiredErrors';
 
-export interface SQFormDialogProps<Values> {
+export interface SQFormDialogProps<Values extends FormikValues> {
   /** The secondary button text (Button located on left side of Dialog) */
   cancelButtonText?: string;
   /** The content to be rendered in the dialog body */
@@ -56,15 +55,12 @@ export interface SQFormDialogProps<Values> {
    * Yup validation schema shape
    * https://jaredpalmer.com/formik/docs/guides/validation#validationschema
    * */
-  validationSchema: Record<
-    keyof Values,
-    AnySchema<Values[keyof Values] | null | undefined>
-  >;
+  validationSchema: AnyObjectSchema;
   /** Callback function invoked when the user clicks the tertiary button */
   onTertiaryClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-function SQFormDialog<Values>({
+function SQFormDialog<Values extends FormikValues>({
   cancelButtonText = 'Cancel',
   children,
   disableBackdropClick = false,
@@ -87,12 +83,6 @@ function SQFormDialog<Values>({
   isTertiaryDisabled = false,
   onTertiaryClick,
 }: SQFormDialogProps<Values>): React.ReactElement {
-  const validationYupSchema = React.useMemo(() => {
-    if (!validationSchema) return;
-
-    return Yup.object().shape(validationSchema);
-  }, [validationSchema]);
-
   const initialErrors = useInitialRequiredErrors(
     validationSchema,
     initialValues
@@ -104,7 +94,7 @@ function SQFormDialog<Values>({
       initialErrors={initialErrors}
       initialValues={initialValues}
       onSubmit={onSave}
-      validationSchema={validationYupSchema}
+      validationSchema={validationSchema}
       validateOnMount={true}
     >
       <SQFormDialogInner

--- a/src/components/SQFormDialogStepper/SQFormDialogStepper.tsx
+++ b/src/components/SQFormDialogStepper/SQFormDialogStepper.tsx
@@ -18,15 +18,14 @@ import type {
   GridProps,
   DialogContentProps,
 } from '@material-ui/core';
-import * as Yup from 'yup';
-import type {AnySchema} from 'yup';
+import type {AnyObjectSchema} from 'yup';
 import {Form, Formik, useFormikContext} from 'formik';
-import type {FormikHelpers} from 'formik';
+import type {FormikHelpers, FormikValues} from 'formik';
 import {RoundedButton} from 'scplus-shared-components';
 import LoadingSpinner from '../LoadingSpinner';
 import type {TransitionProps} from '@material-ui/core/transitions';
 
-export interface SQFormDialogStepProps<Values> {
+export interface SQFormDialogStepProps {
   /** The content to be rendered in the step body. */
   children?: JSX.Element | Array<JSX.Element>;
   /** Should the loading spinner be shown */
@@ -36,14 +35,14 @@ export interface SQFormDialogStepProps<Values> {
   /** The label to display in the stepper */
   label?: string;
   /** Validation schema for this step */
-  validationSchema?: Record<keyof Values, AnySchema>;
+  validationSchema?: AnyObjectSchema;
 }
 
-export function SQFormDialogStep<Values extends Record<string, unknown>>({
+export function SQFormDialogStep({
   children,
   isLoading = false,
   loadingMessage = '',
-}: SQFormDialogStepProps<Values>): JSX.Element {
+}: SQFormDialogStepProps): JSX.Element {
   return isLoading ? (
     <LoadingSpinner message={loadingMessage} />
   ) : (
@@ -99,7 +98,7 @@ const useStepperStyles = makeStyles({
   },
 });
 
-export interface SQFormDialogStepperProps<Values> {
+export interface SQFormDialogStepperProps<Values extends FormikValues> {
   /** The secondary button text (Button located on left side of Dialog) */
   cancelButtonText?: string;
   /** The content to be rendered in the dialog body.  Will be an array of React elements. */
@@ -134,7 +133,7 @@ export interface SQFormDialogStepperProps<Values> {
   contentStyle?: DialogContentProps['style'];
 }
 
-export function SQFormDialogStepper<Values>({
+export function SQFormDialogStepper<Values extends FormikValues>({
   cancelButtonText = 'Cancel',
   children,
   disableBackdropClick = false,
@@ -158,9 +157,7 @@ export function SQFormDialogStepper<Values>({
   const currentChild = steps[activeStep];
   const [completed, setCompleted] = React.useState<number[]>([]);
 
-  const validationSchema = currentChild.props.validationSchema
-    ? Yup.object().shape(currentChild.props.validationSchema)
-    : null;
+  const validationSchema = currentChild.props.validationSchema || null;
 
   const classes = useStyles({steps});
   const actionsClasses = useActionsStyles();

--- a/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.tsx
+++ b/src/components/SQFormGuidedWorkflow/SQFormGuidedWorkflow.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as Yup from 'yup';
 import {Formik, Form} from 'formik';
-import type {FormikHelpers} from 'formik';
+import type {FormikHelpers, FormikValues} from 'formik';
 import {CardActions, CardContent, makeStyles} from '@material-ui/core';
 import {
   Accordion,
@@ -35,11 +35,7 @@ const useStyles = makeStyles(() => {
   };
 });
 
-const getTaskModuleFormSchema = (validationSchema = {}) => {
-  return Yup.object().shape(validationSchema);
-};
-
-function SQFormGuidedWorkflow<TValues extends {[key: string]: unknown}>({
+function SQFormGuidedWorkflow<TValues extends FormikValues>({
   taskModules,
   mainTitle,
   mainSubtitle,
@@ -53,8 +49,10 @@ function SQFormGuidedWorkflow<TValues extends {[key: string]: unknown}>({
   const getFormikInitialRequiredErrors = (
     validationSchema?: SQFormGuidedWorkflowDataProps<TValues>['validationSchema']
   ) => {
-    if (validationSchema) {
-      return Object.entries(validationSchema).reduce((acc, [key, value]) => {
+    if (validationSchema?.fields) {
+      const validationFields =
+        validationSchema.fields as Yup.ObjectSchema<TValues>;
+      return Object.entries(validationFields).reduce((acc, [key, value]) => {
         if (value.tests[0]?.OPTIONS.name === 'required') {
           return {...acc, [key]: 'Required'};
         }
@@ -78,9 +76,7 @@ function SQFormGuidedWorkflow<TValues extends {[key: string]: unknown}>({
   const transformedTaskModules = taskModules.map((taskModule, index) => {
     const taskNumber = index + 1;
     const taskName = taskModule.name;
-    const validationYupSchema = getTaskModuleFormSchema(
-      taskModule.formikProps?.validationSchema
-    );
+    const validationYupSchema = taskModule.formikProps?.validationSchema;
     const initialErrors = getFormikInitialRequiredErrors(
       taskModule.formikProps?.validationSchema
     );

--- a/src/components/SQFormGuidedWorkflow/Types.ts
+++ b/src/components/SQFormGuidedWorkflow/Types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import type {GridProps} from '@material-ui/core';
-import type {FormikHelpers} from 'formik';
-import type {AnySchema} from 'yup';
+import type {FormikHelpers, FormikValues} from 'formik';
+import type {AnyObjectSchema} from 'yup';
 
 export interface SQFormGuidedWorkflowHeaderProps {
   /** Title to display in the section header */
@@ -45,7 +45,7 @@ export interface SQFormGuidedWorkflowOutcomeProps
   muiGridProps?: GridProps;
 }
 
-export interface SQFormGuidedWorkflowDataProps<TValues> {
+export interface SQFormGuidedWorkflowDataProps<TValues extends FormikValues> {
   /** Form Entity Object aka initial values of the form */
   initialValues: TValues;
   /** Form Submission Handler | @typedef onSubmit: (values: Values, formikBag: FormikBag, context) => void | Promise<any> */
@@ -55,13 +55,12 @@ export interface SQFormGuidedWorkflowDataProps<TValues> {
     context: SQFormGuidedWorkflowContext<TValues>
   ) => void | Promise<unknown>;
   /** Yup validation schema shape */
-  validationSchema?: Record<
-    keyof TValues,
-    AnySchema<TValues[keyof TValues] | null | undefined>
-  >;
+  validationSchema?: AnyObjectSchema;
 }
 
-export interface SQFormGuidedWorkflowTaskModuleProps<TValues> {
+export interface SQFormGuidedWorkflowTaskModuleProps<
+  TValues extends FormikValues
+> {
   /** Unique name used as a key for managing expansion state within Accordion */
   name: string;
   /** Title text */
@@ -96,9 +95,7 @@ export interface SQFormGuidedWorkflowTaskModuleProps<TValues> {
   isSubmitButtonDisabled?: boolean;
 }
 
-export interface SQFormGuidedWorkflowProps<
-  TValues extends {[key: string]: unknown}
-> {
+export interface SQFormGuidedWorkflowProps<TValues extends FormikValues> {
   /** Main Title */
   mainTitle: string;
   /** Main Subtitle Informative Text */

--- a/src/components/SQFormScrollableCard/SQFormScrollableCard.tsx
+++ b/src/components/SQFormScrollableCard/SQFormScrollableCard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import * as Yup from 'yup';
 import {
   Card,
   CardHeader,
@@ -9,16 +8,16 @@ import {
   makeStyles,
 } from '@material-ui/core';
 import type {TypographyVariant, GridProps} from '@material-ui/core';
-import type {AnySchema} from 'yup';
+import type {AnyObjectSchema} from 'yup';
 import {Formik, Form} from 'formik';
-import type {FormikHelpers} from 'formik';
+import type {FormikHelpers, FormikValues} from 'formik';
 import {useDebouncedCallback} from 'use-debounce';
 import SQFormButton from '../SQForm/SQFormButton';
 import SQFormHelperText from '../SQForm/SQFormHelperText';
 import {useInitialRequiredErrors} from '../../hooks/useInitialRequiredErrors';
 import {CreateCSSProperties} from '@material-ui/core/styles/withStyles';
 
-export interface SQFormScrollableCardProps<Values> {
+export interface SQFormScrollableCardProps<Values extends FormikValues> {
   /** An object of css-in-js style properties to be passed and spread onto `classes.cardContent` */
   cardContentStyles?: CreateCSSProperties;
   /** Form related Field(s) and components */
@@ -71,10 +70,7 @@ export interface SQFormScrollableCardProps<Values> {
    * Yup validation schema shape
    * https://jaredpalmer.com/formik/docs/guides/validation#validationschema
    * */
-  validationSchema?: Record<
-    keyof Values,
-    AnySchema<Values[keyof Values] | null | undefined>
-  >;
+  validationSchema?: AnyObjectSchema;
   /** Boolean used to determine if title/header is enabled or disabled */
   isHeaderDisabled?: boolean;
   /** MUI Typography variant to be used for the title */
@@ -85,7 +81,7 @@ export interface SQFormScrollableCardProps<Values> {
 
 interface useStylesProps {
   hasSubHeader: boolean;
-  cardContentStyles: SQFormScrollableCardProps<unknown>['cardContentStyles'];
+  cardContentStyles: CreateCSSProperties;
 }
 
 const useStyles = makeStyles((theme) => {
@@ -155,12 +151,6 @@ function SQFormScrollableCard<Values>({
 }: SQFormScrollableCardProps<Values>): React.ReactElement {
   const hasSubHeader = Boolean(SubHeaderComponent);
 
-  const validationYupSchema = React.useMemo(() => {
-    if (!validationSchema) return;
-
-    return Yup.object().shape(validationSchema);
-  }, [validationSchema]);
-
   const initialErrors = useInitialRequiredErrors(
     validationSchema,
     initialValues
@@ -225,7 +215,7 @@ function SQFormScrollableCard<Values>({
         initialErrors={initialErrors}
         initialValues={initialValues}
         onSubmit={handleSubmit}
-        validationSchema={validationYupSchema}
+        validationSchema={validationSchema}
         validateOnMount={true}
       >
         {(_props) => {

--- a/src/hooks/useInitialRequiredErrors.tsx
+++ b/src/hooks/useInitialRequiredErrors.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {AnySchema} from 'yup';
+import type {AnyObjectSchema} from 'yup';
 import type {FormikErrors, FormikValues} from 'formik';
 
 function _getHasValue(fieldValue: unknown) {
@@ -21,12 +21,12 @@ function _getHasValue(fieldValue: unknown) {
 // Until Formik exposes the validationSchema (again) via useFormikContext(), the solution has to be handled at the Form declaration level
 // There's a few open PR's on this issue, here's one for reference: https://github.com/formium/formik/pull/2933
 export function useInitialRequiredErrors<Values>(
-  validationSchema: AnySchema | Record<string, unknown> = {},
+  validationSchema: AnyObjectSchema | undefined,
   initialValues: FormikValues
 ): FormikErrors<Values> {
   const initialRequiredErrorsRef = React.useRef(
-    Object.entries(validationSchema).reduce((acc, [key, value]) => {
-      if (value._exclusive?.required && !_getHasValue(initialValues[key])) {
+    Object.entries(validationSchema || {}).reduce((acc, [key, value]) => {
+      if (value?._exclusive?.required && !_getHasValue(initialValues[key])) {
         return {...acc, [key]: 'Required'};
       }
       return acc;

--- a/stories/SQForm.stories.tsx
+++ b/stories/SQForm.stories.tsx
@@ -238,7 +238,7 @@ export const BasicForm = (): JSX.Element => {
 };
 
 export const FormWithValidation = (): JSX.Element => {
-  const validationSchema = {
+  const validationSchema = Yup.object({
     firstName: Yup.string().required(),
     lastName: Yup.string().required(),
     city: Yup.string(),
@@ -256,7 +256,7 @@ export const FormWithValidation = (): JSX.Element => {
       )
       .required()
       .min(1),
-  };
+  });
 
   return (
     <Card raised style={{padding: 16}}>
@@ -457,9 +457,9 @@ export const formWithInclusionlist = (): JSX.Element => {
 };
 
 export const basicFormWithMultiSelect = (): JSX.Element => {
-  const validationSchema = {
+  const validationSchema = Yup.object({
     friends: Yup.array().of(Yup.string()).required().min(1, 'Required'),
-  };
+  });
 
   return (
     <Card raised style={{padding: '16px', minWidth: '768px'}}>
@@ -491,7 +491,7 @@ export const basicFormWithMultiSelect = (): JSX.Element => {
 };
 
 export const basicFormWithMaskedFields = (): JSX.Element => {
-  const validationSchema = {
+  const validationSchema = Yup.object({
     phone: Yup.string()
       .required()
       .transform((value) => value.replace(/[^\d]/g, ''))
@@ -501,7 +501,7 @@ export const basicFormWithMaskedFields = (): JSX.Element => {
       .transform((value) => value.replace(/[^\d]/g, ''))
       .min(5, 'Zip code must be 5 digits'),
     currency: Yup.string().required(),
-  };
+  });
 
   return (
     <Card raised style={{padding: '16px', minWidth: '768px'}}>
@@ -683,9 +683,9 @@ export const basicFormWithCustomOnChange = (): JSX.Element => {
 };
 
 export const applyAnAction = (): JSX.Element => {
-  const validationSchema = {
+  const validationSchema = Yup.object({
     actions: Yup.string().required(),
-  };
+  });
 
   return (
     <Card raised style={{padding: '16px', minWidth: '768px'}}>
@@ -729,11 +729,11 @@ export const SQFormCheckboxGroupExample = (): JSX.Element => {
     selectAll: false,
   };
 
-  const validationSchema = {
+  const validationSchema = Yup.object({
     warrantyOptions: Yup.array()
       .min(1, 'Must select at least 1 option')
       .required(),
-  };
+  });
 
   return (
     <Card raised style={{padding: '16px', minWidth: '250px'}}>
@@ -765,11 +765,11 @@ export const ccaChecklist = (): JSX.Element => {
     {label: 'Pitched', value: 'pitched'},
     {label: 'Transferred', value: 'transferred'},
   ];
-  const validationSchema = {
+  const validationSchema = Yup.object({
     dvh: Yup.string(),
     hra: Yup.string(),
     shield: Yup.string(),
-  };
+  });
 
   return (
     <Card raised style={{padding: '16px', minWidth: '768px'}}>

--- a/stories/SQFormAsyncAutocomplete.stories.tsx
+++ b/stories/SQFormAsyncAutocomplete.stories.tsx
@@ -1,8 +1,6 @@
 import {action} from '@storybook/addon-actions';
 import React from 'react';
 import * as Yup from 'yup';
-import {AnySchema} from 'yup';
-
 import {SQFormAsyncAutocomplete} from '../src';
 import getSizeProp from './utils/getSizeProp';
 import {createDocsPage} from './utils/createDocsPage';
@@ -20,7 +18,7 @@ type SQFormAsyncAutocompleteStory = Story<
   Omit<SQFormAsyncAutocompleteProps, 'size'> & {
     size?: GridSizeOptions;
     sqFormProps?: FormProps;
-    schema: Record<string, AnySchema>;
+    schema: SQFormStoryWrapperProps['validationSchema'];
   }
 >;
 
@@ -95,9 +93,9 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  schema: {
+  schema: Yup.object({
     [defaultArgs.name]: Yup.string().required(),
-  },
+  }),
 };
 WithValidation.parameters = {
   controls: {exclude: 'schema'},

--- a/stories/SQFormAutocomplete.stories.tsx
+++ b/stories/SQFormAutocomplete.stories.tsx
@@ -1,26 +1,25 @@
 import React from 'react';
 import * as Yup from 'yup';
-import type { AnySchema } from 'yup';
 import type {Story, Meta} from '@storybook/react';
 import {SQFormAutocomplete} from '../src';
-import type { SQFormAutocompleteProps } from 'components/SQForm/SQFormAutocomplete';
+import type {SQFormAutocompleteProps} from 'components/SQForm/SQFormAutocomplete';
 import getSizeProp from './utils/getSizeProp';
 import {createDocsPage} from './utils/createDocsPage';
 import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
-import type { SQFormStoryWrapperProps } from './components/SQFormStoryWrapper';
-import type { GridSizeOptions } from './types/storyHelperTypes';
+import type {SQFormStoryWrapperProps} from './components/SQFormStoryWrapper';
+import type {GridSizeOptions} from './types/storyHelperTypes';
 
 type FormProps = {
-    initialValues?: SQFormStoryWrapperProps['initialValues'];
- } & Omit<SQFormStoryWrapperProps, 'initialValues' | 'children'>;
+  initialValues?: SQFormStoryWrapperProps['initialValues'];
+} & Omit<SQFormStoryWrapperProps, 'initialValues' | 'children'>;
 
 type SQFormAutocompleteStory = Story<
   Omit<SQFormAutocompleteProps, 'size'> & {
     size?: GridSizeOptions;
     sqFormProps?: FormProps;
-    schema: Record<string, AnySchema>;
+    schema: SQFormStoryWrapperProps['validationSchema'];
   }
->
+>;
 
 const meta: Meta = {
   title: 'Components/SQFormAutocomplete',
@@ -89,9 +88,9 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  schema: {
+  schema: Yup.object({
     [defaultArgs.name]: Yup.string().required(),
-  },
+  }),
 };
 WithValidation.parameters = {
   controls: {exclude: 'schema'},

--- a/stories/SQFormCheckboxGroup.stories.tsx
+++ b/stories/SQFormCheckboxGroup.stories.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import * as Yup from 'yup';
-import type {AnySchema} from 'yup';
 import type {Story, Meta} from '@storybook/react';
 import {SQFormCheckboxGroup as SQFormCheckboxGroupComponent} from '../src';
 import {createDocsPage} from './utils/createDocsPage';
 import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
+import type {SQFormStoryWrapperProps} from './components/SQFormStoryWrapper';
 import type {SQFormCheckboxGroupProps} from 'components/SQForm/SQFormCheckboxGroup';
 
 export default {
@@ -43,7 +43,7 @@ const defaultArgs = {
 
 interface CheckboxGroupTestProps extends SQFormCheckboxGroupProps {
   initialValues: Record<string, string[] | boolean>;
-  schema: Record<string, AnySchema>;
+  schema: SQFormStoryWrapperProps['validationSchema'];
 }
 
 export const Default: Story<CheckboxGroupTestProps> = (args) => {
@@ -76,9 +76,9 @@ export const WithValidation: Story<CheckboxGroupTestProps> = (args) => {
 
 WithValidation.args = {
   ...defaultArgs,
-  schema: {
+  schema: Yup.object({
     [defaultArgs.name]: Yup.array().required().min(1, 'Required'),
-  },
+  }),
 };
 
 WithValidation.parameters = {

--- a/stories/SQFormDatePicker.stories.tsx
+++ b/stories/SQFormDatePicker.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import * as Yup from 'yup';
-import type {AnySchema} from 'yup';
 import {SQFormDatePicker as SQFormDatePickerComponent} from '../src';
 import {createDocsPage} from './utils/createDocsPage';
 import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
@@ -16,7 +15,7 @@ export type FormProps = {
 export type SQFormDatePickerStory = Story<
   Omit<SQFormDatePickerProps, 'label' | 'name'> & {
     sqFormProps?: FormProps;
-    schema: Record<string, AnySchema>;
+    schema: SQFormStoryWrapperProps['validationSchema'];
   }
 >;
 
@@ -64,24 +63,24 @@ const Template: SQFormDatePickerStory = (args) => {
 export const BasicDatePicker = Template.bind({});
 BasicDatePicker.args = {
   ...defaultArgs,
-  schema: {
+  schema: Yup.object({
     date: Yup.date()
       .required()
       .min(new Date('2020-09-22'))
       .max(new Date('2100-10-10'))
       .typeError('Invalid date'),
-  },
+  }),
 };
 
 export const DatePickerBefore2024 = Template.bind({});
 DatePickerBefore2024.args = {
   ...defaultArgs,
-  schema: {
+  schema: Yup.object({
     date: Yup.date()
       .required()
       .max(new Date('2024-01-01'), 'Date must be before 2024')
       .typeError('Invalid date'),
-  },
+  }),
 };
 
 export default meta;

--- a/stories/SQFormDatePickerWithCalendarInputOnly.stories.tsx
+++ b/stories/SQFormDatePickerWithCalendarInputOnly.stories.tsx
@@ -26,9 +26,9 @@ const MOCK_INITIAL_STATE = {
   date: '12/01/1990',
 };
 
-const basicSchema = {
+const basicSchema = Yup.object({
   date: Yup.date().required().typeError('Invalid date'),
-};
+});
 
 const defaultArgs = {
   label: 'Date',

--- a/stories/SQFormDateTimePicker.stories.tsx
+++ b/stories/SQFormDateTimePicker.stories.tsx
@@ -4,9 +4,9 @@ import {SQFormDateTimePicker as SQFormDateTimePickerComponent} from '../src';
 import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
 import {createDocsPage} from './utils/createDocsPage';
 import markdown from '../notes/SQFormDatePicker.md';
-import type { Meta } from '@storybook/react';
-import type { CustomStory } from './types/storyHelperTypes';
-import type { SQFormDateTimePickerProps } from 'components/SQForm/SQFormDateTimePicker';
+import type {Meta} from '@storybook/react';
+import type {CustomStory} from './types/storyHelperTypes';
+import type {SQFormDateTimePickerProps} from 'components/SQForm/SQFormDateTimePicker';
 import getSizeProp from './utils/getSizeProp';
 
 const meta: Meta = {
@@ -15,31 +15,31 @@ const meta: Meta = {
   argTypes: {
     onBlur: {action: 'blurred', table: {disable: true}},
     onChange: {action: 'changed', table: {disable: true}},
-    name: {table: {disable: true}}
+    name: {table: {disable: true}},
   },
   parameters: {
-    docs: {page: createDocsPage({markdown})}
-  }
+    docs: {page: createDocsPage({markdown})},
+  },
 };
 
 const MOCK_INITIAL_STATE = {
-  datetime: '09/22/2020 02:20 PM'
+  datetime: '09/22/2020 02:20 PM',
 };
 
-const schema = {
+const schema = Yup.object({
   datetime: Yup.date()
     .required()
     .min(new Date('2020-09-22'))
     .max(new Date('2100-10-10'))
-    .typeError('Invalid date')
-};
+    .typeError('Invalid date'),
+});
 
 const defaultArgs = {
   label: 'Date/Time',
-  name: 'datetime'
+  name: 'datetime',
 };
 
-const Template: CustomStory<SQFormDateTimePickerProps> = args => {
+const Template: CustomStory<SQFormDateTimePickerProps> = (args) => {
   const {schema, sqFormProps, ...rest} = args;
   return (
     <SQFormStoryWrapper
@@ -47,13 +47,10 @@ const Template: CustomStory<SQFormDateTimePickerProps> = args => {
       validationSchema={schema}
       {...sqFormProps}
     >
-      <SQFormDateTimePickerComponent
-        {...rest}
-        size={getSizeProp(args.size)}
-      />
+      <SQFormDateTimePickerComponent {...rest} size={getSizeProp(args.size)} />
     </SQFormStoryWrapper>
-  )
-}
+  );
+};
 
 export const BasicDateTimePicker = Template.bind({});
 BasicDateTimePicker.storyName = 'BasicDateTimePicker';
@@ -63,10 +60,9 @@ export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
   schema,
-}
+};
 WithValidation.parameters = {
-  controls: {exclude: 'schema'}
-}
+  controls: {exclude: 'schema'},
+};
 
 export default meta;
-

--- a/stories/SQFormDialog.stories.tsx
+++ b/stories/SQFormDialog.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as Yup from 'yup';
 import type {Story, Meta} from '@storybook/react';
-import type { GridItemsAlignment, GridSpacing } from '@material-ui/core';
+import type {GridItemsAlignment, GridSpacing} from '@material-ui/core';
 
 import {
   SQFormDialog,
@@ -10,18 +10,20 @@ import {
   SQFormDateTimePicker,
   SQFormDatePickerWithCalendarInputOnly,
 } from '../src';
-import type { SQFormDialogProps } from 'components/SQFormDialog/SQFormDialog';
+import type {SQFormDialogProps} from 'components/SQFormDialog/SQFormDialog';
 import {createDocsPage} from './utils/createDocsPage';
 
-type DefaultArgsValues = { hello: string };
-type SQFormDialogStory = Story<SQFormDialogProps<DefaultArgsValues>>
+type DefaultArgsValues = {hello: string};
+type SQFormDialogStory = Story<SQFormDialogProps<DefaultArgsValues>>;
 
 type WithDatePickersValues = {
-  datePicker: string,
-  dateTimePicker: string,
-  datePickerCalendarOnly: string,
-}
-type SQFormDialogWithDatePickersStory = Story<SQFormDialogProps<WithDatePickersValues>>;
+  datePicker: string;
+  dateTimePicker: string;
+  datePickerCalendarOnly: string;
+};
+type SQFormDialogWithDatePickersStory = Story<
+  SQFormDialogProps<WithDatePickersValues>
+>;
 
 const meta: Meta = {
   title: 'Forms/SQFormDialog',
@@ -73,9 +75,9 @@ export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
   title: 'With Validation',
-  validationSchema: {
+  validationSchema: Yup.object({
     hello: Yup.string().required(),
-  },
+  }),
 };
 
 export const WithAutoFocus: SQFormDialogStory = (args) => {
@@ -100,7 +102,7 @@ WithAutoFocus.args = {
   title: 'With Auto Focus',
 };
 
-export const WithDatePickers: SQFormDialogWithDatePickersStory= (args) => {
+export const WithDatePickers: SQFormDialogWithDatePickersStory = (args) => {
   return (
     <>
       <h1>
@@ -144,7 +146,7 @@ export const WithTertiaryButton: SQFormDialogStory = (args) => {
 WithTertiaryButton.args = {
   ...defaultArgs,
   initialValues: {
-    hello: ''
+    hello: '',
   },
   title: 'With Tertiary Button',
   showTertiaryButton: true,

--- a/stories/SQFormDialogStepper.stories.tsx
+++ b/stories/SQFormDialogStepper.stories.tsx
@@ -113,24 +113,24 @@ export const WithValidation = (
       <SQFormDialogStepperComponent {...args}>
         <SQFormDialogStep
           label="Personal Data"
-          validationSchema={{
+          validationSchema={Yup.object({
             firstName: Yup.string().required(),
             lastName: Yup.string().required(),
-          }}
+          })}
         >
           <SQFormTextField size={6} name="firstName" label="First Name" />
           <SQFormTextField size={6} name="lastName" label="Last Name" />
         </SQFormDialogStep>
         <SQFormDialogStep
           label="Account Info"
-          validationSchema={{
+          validationSchema={Yup.object({
             accountID: Yup.mixed().when('newPatient', {
               is: (value: string) => value === 'yes',
               then: Yup.number()
                 .required()
                 .min(100, 'Required for new account'),
             }),
-          }}
+          })}
         >
           <SQFormDropdown
             name="newPatient"

--- a/stories/SQFormDisableableComponents.stories.tsx
+++ b/stories/SQFormDisableableComponents.stories.tsx
@@ -36,7 +36,7 @@ export const disableableComponents = (): React.ReactElement => {
     checkbox: true,
   };
 
-  const validationSchema = {
+  const validationSchema = Yup.object({
     autoComplete: Yup.string(),
     datePicker: Yup.date(),
     calendarInputOnly: Yup.date(),
@@ -46,7 +46,7 @@ export const disableableComponents = (): React.ReactElement => {
     textField: Yup.string(),
     textArea: Yup.string(),
     checkbox: Yup.boolean(),
-  };
+  });
 
   const onSubmit = (formValues: typeof initialValues) => {
     window.alert(JSON.stringify(formValues, null, 2));

--- a/stories/SQFormDropdown.stories.tsx
+++ b/stories/SQFormDropdown.stories.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import type {AnySchema} from 'yup'; 
-
 import {SQFormDropdown as SQFormDropdownComponent} from '../src';
 import type {SQFormDropdownProps} from 'components/SQForm/SQFormDropdown';
 import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
 import type {SQFormStoryWrapperProps} from './components/SQFormStoryWrapper';
 import getSizeProp from './utils/getSizeProp';
 import type {GridSizeOptions} from './types/storyHelperTypes';
-import type { Meta, Story } from '@storybook/react';
+import type {Meta, Story} from '@storybook/react';
 import {createDocsPage} from './utils/createDocsPage';
 import * as markdown from '../notes/SQFormDropdown.md';
 
@@ -16,13 +14,12 @@ type FormProps = {
 } & Omit<SQFormStoryWrapperProps, 'initalValues' | 'children'>;
 
 type DropdownStoryType = Story<
-  Omit<SQFormDropdownProps, 'size'> &
-  {
-   size?: GridSizeOptions,
-   sqFormProps?: FormProps,
-   schema: Record<string, AnySchema>
+  Omit<SQFormDropdownProps, 'size'> & {
+    size?: GridSizeOptions;
+    sqFormProps?: FormProps;
+    schema: SQFormStoryWrapperProps['validationSchema'];
   }
->
+>;
 
 const meta: Meta = {
   title: 'Components/SQFormDropdown',

--- a/stories/SQFormGuidedWorkflow.stories.tsx
+++ b/stories/SQFormGuidedWorkflow.stories.tsx
@@ -75,10 +75,10 @@ const Template: CustomStory<
             setIsModuleDisabled(false);
           }
         },
-        validationSchema: {
+        validationSchema: Yup.object({
           outcome: Yup.string().required(),
           notes: Yup.string(),
-        },
+        }),
       },
       additionalInformationSectionProps: {
         Elements: (
@@ -135,10 +135,10 @@ const Template: CustomStory<
           console.log(values);
           console.log(context);
         },
-        validationSchema: {
+        validationSchema: Yup.object({
           outcome: Yup.string().required(),
           notes: Yup.string(),
-        },
+        }),
       },
       scriptedTextProps: {
         text: `Stuff about policy cancellation documents`,
@@ -183,10 +183,10 @@ const Template: CustomStory<
           console.log(values);
           console.log(context);
         },
-        validationSchema: {
+        validationSchema: Yup.object({
           outcome: Yup.string().required(),
           notes: Yup.string(),
-        },
+        }),
       },
       additionalInformationSectionProps: {
         Elements: (
@@ -293,80 +293,81 @@ type InitialValuesType =
   | typeof firstSectionInitialValues
   | typeof secondSectionInitialValues;
 
-const TestTemplate: CustomStory<SQFormGuidedWorkflowProps<InitialValuesType>> =
-  (args): React.ReactElement => {
-    const {mainTitle, ...rest} = args;
+const TestTemplate: CustomStory<
+  SQFormGuidedWorkflowProps<InitialValuesType>
+> = (args): React.ReactElement => {
+  const {mainTitle, ...rest} = args;
 
-    const taskModules = [
-      {
-        name: 'firstSection',
-        title: 'First Section',
-        formikProps: {
-          initialValues: firstSectionInitialValues,
-          onSubmit: async (values: InitialValuesType) => {
-            console.log(JSON.stringify(values));
-          },
-          validationSchema: {
-            firstText: Yup.string().required(),
-            secondText: Yup.string(),
-          },
+  const taskModules = [
+    {
+      name: 'firstSection',
+      title: 'First Section',
+      formikProps: {
+        initialValues: firstSectionInitialValues,
+        onSubmit: async (values: InitialValuesType) => {
+          console.log(JSON.stringify(values));
         },
-        scriptedTextProps: {
-          text: 'This is some text',
-          title: 'Script Title',
-        },
-        outcomeProps: {
-          FormElements: (
-            <>
-              <SQFormTextField name="firstText" label="First Text" />
-              <SQFormTextField name="secondText" label="Second Text" />
-            </>
-          ),
-          title: 'Outcome Test',
+        validationSchema: Yup.object({
+          firstText: Yup.string().required(),
+          secondText: Yup.string(),
+        }),
+      },
+      scriptedTextProps: {
+        text: 'This is some text',
+        title: 'Script Title',
+      },
+      outcomeProps: {
+        FormElements: (
+          <>
+            <SQFormTextField name="firstText" label="First Text" />
+            <SQFormTextField name="secondText" label="Second Text" />
+          </>
+        ),
+        title: 'Outcome Test',
+      },
+    },
+    {
+      name: 'secondSection',
+      title: 'Second Section',
+      formikProps: {
+        initialValues: secondSectionInitialValues,
+        onSubmit: async (values: InitialValuesType) => {
+          console.log(JSON.stringify(values));
         },
       },
-      {
-        name: 'secondSection',
-        title: 'Second Section',
-        formikProps: {
-          initialValues: secondSectionInitialValues,
-          onSubmit: async (values: InitialValuesType) => {
-            console.log(JSON.stringify(values));
-          },
-        },
-        scriptedTextProps: {
-          text: 'This is some more text',
-          title: 'Another Script Title',
-        },
-        outcomeProps: {
-          FormElements: (
-            <>
-              <SQFormTextField name="testText" label="Test Text" />
-              <SQFormTextarea name="notes" label="Notes" />
-            </>
-          ),
-          title: 'Outcome Test',
-        },
+      scriptedTextProps: {
+        text: 'This is some more text',
+        title: 'Another Script Title',
       },
-    ];
+      outcomeProps: {
+        FormElements: (
+          <>
+            <SQFormTextField name="testText" label="Test Text" />
+            <SQFormTextarea name="notes" label="Notes" />
+          </>
+        ),
+        title: 'Outcome Test',
+      },
+    },
+  ];
 
-    return (
-      <div style={{width: '90%', height: '95vh'}}>
-        <ExpandingCardList>
-          <ExpandingCard title="Guided Workflow Test" name="guidedWorkflowTest">
-            <SQFormGuidedWorkflow<InitialValuesType>
-              {...rest}
-              mainTitle={mainTitle}
-              onError={(error) => {
-                console.error(error);
-              }}
-              taskModules={taskModules}
-            />
-          </ExpandingCard>
-        </ExpandingCardList>
-      </div>
-    );
-  };
+  return (
+    <div style={{width: '90%', height: '95vh'}}>
+      <ExpandingCardList>
+        <ExpandingCard title="Guided Workflow Test" name="guidedWorkflowTest">
+          <SQFormGuidedWorkflow<InitialValuesType>
+            {...rest}
+            mainTitle={mainTitle}
+            onError={(error) => {
+              console.error(error);
+            }}
+            taskModules={taskModules}
+          />
+        </ExpandingCard>
+      </ExpandingCardList>
+    </div>
+  );
+};
 
 export const Testing = TestTemplate.bind({});
 Testing.args = {

--- a/stories/SQFormInclusionList.stories.tsx
+++ b/stories/SQFormInclusionList.stories.tsx
@@ -111,9 +111,9 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  schema: {
+  schema: Yup.object({
     friends: Yup.array().min(5),
-  },
+  }),
 };
 WithValidation.parameters = {
   controls: {exclude: 'schema'},

--- a/stories/SQFormMaskedTextField.stories.tsx
+++ b/stories/SQFormMaskedTextField.stories.tsx
@@ -11,7 +11,6 @@ import type {SQFormStoryWrapperProps} from './components/SQFormStoryWrapper';
 import type {Story} from '@storybook/react';
 import type {SQFormMaskedTextFieldProps} from 'components/SQForm/SQFormMaskedTextField';
 import type {GridSizeOptions} from './types/storyHelperTypes';
-import type {AnySchema} from 'yup';
 import type {Mask} from 'types';
 
 export default {
@@ -33,7 +32,7 @@ type MaskedTextFieldStoryType = Story<
   Omit<SQFormMaskedTextFieldProps, 'size'> & {
     size?: GridSizeOptions;
     sqFormProps?: SQFormStoryWrapperProps;
-    schema: Record<string, AnySchema>;
+    schema: SQFormStoryWrapperProps['validationSchema'];
     exampleMasks: Mask;
   }
 >;

--- a/stories/SQFormMultiSelect.stories.tsx
+++ b/stories/SQFormMultiSelect.stories.tsx
@@ -10,14 +10,13 @@ import {createDocsPage} from './utils/createDocsPage';
 import type {Story} from '@storybook/react';
 import type {SQFormMultiSelectProps} from 'components/SQForm/SQFormMultiSelect';
 import type {GridSizeOptions} from './types/storyHelperTypes';
-import type {AnySchema} from 'yup';
 import getSizeProp from './utils/getSizeProp';
 
 type MultiSelectStoryType = Story<
   Omit<SQFormMultiSelectProps, 'size' | 'name' | 'label'> & {
     size?: GridSizeOptions;
     sqFormProps?: Omit<SQFormStoryWrapperProps, 'children'>;
-    validationSchema: Record<string, AnySchema>;
+    validationSchema: SQFormStoryWrapperProps['validationSchema'];
   }
 >;
 
@@ -90,9 +89,9 @@ SQFormMultiSelect.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  validationSchema: {
+  validationSchema: Yup.object({
     friends: Yup.array().required().min(1, 'Required'),
-  },
+  }),
   sqFormProps: {
     initialValues: {friends: []},
   },

--- a/stories/SQFormMultiValue.stories.tsx
+++ b/stories/SQFormMultiValue.stories.tsx
@@ -69,7 +69,7 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  schema: {
+  schema: Yup.object({
     favoriteColors: Yup.array()
       .of(
         Yup.lazy((value: unknown) => {
@@ -78,7 +78,7 @@ WithValidation.args = {
       )
       .required()
       .min(1, 'Required'),
-  },
+  }),
   sqFormProps: {
     initialValues: {favoriteColors: []},
   },

--- a/stories/SQFormRadioButtonGroup.stories.tsx
+++ b/stories/SQFormRadioButtonGroup.stories.tsx
@@ -11,13 +11,12 @@ import {
 import type {Story} from '@storybook/react';
 import type {SQFormRadioButtonGroupProps} from 'components/SQForm/SQFormRadioButtonGroup';
 import type {GridSizeOptions} from './types/storyHelperTypes';
-import type {AnySchema} from 'yup';
 
 type RadioButtonGroupType = Story<
   Omit<SQFormRadioButtonGroupProps, 'size'> & {
     size?: GridSizeOptions;
     sqFormProps: Partial<SQFormStoryWrapperProps>;
-    schema: Record<string, AnySchema>;
+    schema: SQFormStoryWrapperProps['validationSchema'];
   }
 >;
 
@@ -77,9 +76,9 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  schema: {
+  schema: Yup.object({
     [defaultArgs.name]: Yup.string().required(),
-  },
+  }),
 };
 WithValidation.parameters = {
   controls: {exclude: 'schema'},

--- a/stories/SQFormScrollableCard.stories.tsx
+++ b/stories/SQFormScrollableCard.stories.tsx
@@ -38,7 +38,7 @@ const defaultArgs = {
   onSubmit: () => {
     /* do nothing */
   },
-  validationSchema: {hello: Yup.string().required()},
+  validationSchema: Yup.object({hello: Yup.string().required().min(15)}),
 };
 
 const Template: CustomStory<

--- a/stories/SQFormScrollableCardsMenuWrapper.stories.tsx
+++ b/stories/SQFormScrollableCardsMenuWrapper.stories.tsx
@@ -1,6 +1,6 @@
 import type {FormikHelpers} from 'formik';
 import React from 'react';
-import * as yup from 'yup';
+import * as Yup from 'yup';
 
 import {
   SQFormScrollableCardsMenuWrapper,
@@ -34,9 +34,9 @@ function ScrollableDetails(): React.ReactElement {
     name: '',
   };
 
-  const validationSchema = {
-    name: yup.string().required(),
-  };
+  const validationSchema = Yup.object({
+    name: Yup.string().required().min(12),
+  });
 
   const handleSubmit = (
     values: typeof initialValues,
@@ -66,9 +66,9 @@ function ScrollablePermissions(): React.ReactElement {
     isAdmin: false,
   };
 
-  const validationSchema = {
-    isAdmin: yup.boolean(),
-  };
+  const validationSchema = Yup.object({
+    isAdmin: Yup.boolean(),
+  });
 
   const handleSubmit = (
     values: typeof initialValues,

--- a/stories/SQFormTextField.stories.tsx
+++ b/stories/SQFormTextField.stories.tsx
@@ -59,9 +59,9 @@ WithValidation.args = {
   ...defaultArgs,
   isRequired: true,
   SQFormProps: {
-    validationSchema: {
+    validationSchema: Yup.object({
       [defaultArgs.name]: Yup.string().required('Required'),
-    },
+    }),
   },
 };
 WithValidation.parameters = {

--- a/stories/SQFormTextarea.stories.tsx
+++ b/stories/SQFormTextarea.stories.tsx
@@ -1,28 +1,26 @@
 import React from 'react';
 import * as Yup from 'yup';
-import { AnySchema } from 'yup';
 import type {Story, Meta} from '@storybook/react';
 
 import {SQFormTextarea as SQFormTextareaComponent} from '../src';
-import type { SQFormTextareaProps } from 'components/SQForm/SQFormTextarea';
+import type {SQFormTextareaProps} from 'components/SQForm/SQFormTextarea';
 import getSizeProp from './utils/getSizeProp';
 import {createDocsPage} from './utils/createDocsPage';
 import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
 import type {SQFormStoryWrapperProps} from './components/SQFormStoryWrapper';
-import type { GridSizeOptions } from './types/storyHelperTypes';
+import type {GridSizeOptions} from './types/storyHelperTypes';
 
 type FormProps = {
   initialValues?: SQFormStoryWrapperProps['initialValues'];
 } & Omit<SQFormStoryWrapperProps, 'initialValues' | 'children'>;
 
 type SQFormTextAreaStory = Story<
-  Omit<SQFormTextareaProps, 'size'> &
-  {
-    size: GridSizeOptions,
-    sqFormProps?: FormProps,
-    schema: Record<string, AnySchema>,
+  Omit<SQFormTextareaProps, 'size'> & {
+    size: GridSizeOptions;
+    sqFormProps?: FormProps;
+    schema: SQFormStoryWrapperProps['validationSchema'];
   }
->
+>;
 
 const meta: Meta = {
   title: 'Components/SQFormTextarea',
@@ -63,9 +61,9 @@ Default.args = defaultArgs;
 export const WithValidation = Template.bind({});
 WithValidation.args = {
   ...defaultArgs,
-  schema: {
+  schema: Yup.object({
     [defaultArgs.name]: Yup.string().required(),
-  },
+  }),
 };
 WithValidation.parameters = {
   controls: {exclude: 'schema'},

--- a/stories/__tests__/SQFormDatePicker.stories.test.tsx
+++ b/stories/__tests__/SQFormDatePicker.stories.test.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import * as stories from '../SQFormDatePicker.stories';
 import type {SQFormDatePickerProps} from 'components/SQForm/SQFormDatePicker';
 import type {FormProps} from '../SQFormDatePicker.stories';
-import type {AnySchema} from 'yup';
+import type {AnyObjectSchema} from 'yup';
 
 const {BasicDatePicker} = composeStories(stories);
 
@@ -15,7 +15,7 @@ const renderDatePicker = (
   props?: Partial<
     Omit<SQFormDatePickerProps, 'label' | 'name'> & {
       sqFormProps?: FormProps | undefined;
-      schema: Record<string, AnySchema<unknown, unknown, unknown>>;
+      schema: AnyObjectSchema;
     }
   >
 ) => {

--- a/stories/__tests__/SQFormDropdown.stories.test.tsx
+++ b/stories/__tests__/SQFormDropdown.stories.test.tsx
@@ -53,8 +53,8 @@ it('should update when option is selected', () => {
 it('should display disabled option', () => {
   render(<SQFormDropdown size="auto" />);
 
-  const disabledOptionBefore = screen.queryByRole('option', { name: /kansas/i});
-  
+  const disabledOptionBefore = screen.queryByRole('option', {name: /kansas/i});
+
   expect(disabledOptionBefore).not.toBeInTheDocument();
 
   const expandButton = screen.getByRole('button', {name: /state/i});
@@ -120,9 +120,9 @@ it('should be selectable if it is not disabled', () => {
 
 it('should display icon and text if field is required', async () => {
   const formProps = {
-    validationSchema: { state: Yup.string().required(), },
-    initialValues: { state: ''},
-  }
+    validationSchema: Yup.object({state: Yup.string().required()}),
+    initialValues: {state: ''},
+  };
 
   render(<SQFormDropdown sqFormProps={formProps} size="auto" />);
 
@@ -131,9 +131,9 @@ it('should display icon and text if field is required', async () => {
 
 it('should not display icon and text if field is not required', () => {
   const formProps = {
-    validationSchema: { state: Yup.string(), },
-    initialValues:  { state: '' }
-  }
+    validationSchema: Yup.object({state: Yup.string()}),
+    initialValues: {state: ''},
+  };
 
   render(<SQFormDropdown sqFormProps={formProps} size="auto" />);
 
@@ -143,9 +143,9 @@ it('should not display icon and text if field is not required', () => {
 
 it('should highlight field if required but no value selected', async () => {
   const formProps = {
-    validationSchema:  { state: Yup.string().required(), },
+    validationSchema: Yup.object({state: Yup.string().required()}),
     initialValues: {state: ''},
-  }
+  };
 
   render(<SQFormDropdown sqFormProps={formProps} size="auto" />);
 
@@ -163,9 +163,9 @@ it('should highlight field if required but no value selected', async () => {
 });
 
 it('should show empty list if no options are given', () => {
-  const consoleWarnSpy = jest
-    .spyOn(console, 'warn')
-    .mockImplementation(() => {});
+  const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {
+    /* do nothing */
+  });
 
   render(<SQFormDropdown size="auto" children={undefined} />);
 
@@ -181,9 +181,9 @@ it('should show empty list if no options are given', () => {
 });
 
 it('should show empty value if initial value not in options', () => {
-  const consoleWarnSpy = jest
-    .spyOn(console, 'warn')
-    .mockImplementation(() => {});
+  const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {
+    /* do nothing */
+  });
 
   render(
     <SQFormDropdown size="auto" sqFormProps={{initialValues: {state: 'TX'}}} />

--- a/stories/__tests__/SQFormInclusionList.stories.test.tsx
+++ b/stories/__tests__/SQFormInclusionList.stories.test.tsx
@@ -103,9 +103,9 @@ describe('SQFormInclusionList Tests', () => {
       initialValues: {
         friends: [],
       },
-      validationSchema: {
+      validationSchema: Yup.object({
         friends: Yup.array().required().min(1),
-      },
+      }),
     };
 
     render(<SQFormInclusionList sqFormProps={sqFormProps} />);
@@ -123,9 +123,9 @@ describe('SQFormInclusionList Tests', () => {
       initialValues: {
         friends: [],
       },
-      validationSchema: {
+      validationSchema: Yup.object({
         friends: Yup.array().required().min(1),
-      },
+      }),
     };
 
     render(<SQFormInclusionList sqFormProps={sqFormProps} />);

--- a/stories/components/SQFormStoryWrapper.tsx
+++ b/stories/components/SQFormStoryWrapper.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type {AnyObjectSchema} from 'yup';
 import Grid from '@material-ui/core/Grid';
 import type {GridProps} from '@material-ui/core';
 import {SQForm, SQFormButton} from '../../src';
@@ -8,12 +9,11 @@ import {
   useSnackbar,
 } from 'scplus-shared-components';
 import type {FormikValues} from 'formik';
-import type {AnySchema} from 'yup';
 
 export interface SQFormStoryWrapperProps {
   children: React.ReactNode;
   initialValues: FormikValues;
-  validationSchema?: Record<string, AnySchema>;
+  validationSchema?: AnyObjectSchema;
   muiGridProps?: GridProps;
   showSubmit?: boolean;
 }

--- a/stories/types/storyHelperTypes.ts
+++ b/stories/types/storyHelperTypes.ts
@@ -1,6 +1,5 @@
-import type { SQFormStoryWrapperProps } from '../components/SQFormStoryWrapper';
+import type {SQFormStoryWrapperProps} from '../components/SQFormStoryWrapper';
 import type {Story} from '@storybook/react';
-import type { AnySchema } from 'yup';
 
 /** String 'undefined' has to be added due to the way
  * Storybook handles `undefined` in dropdown options.
@@ -24,13 +23,13 @@ export type GridSizeOptions =
   | '12';
 
 type FormProps = {
-    initialValues?: SQFormStoryWrapperProps['initialValues'];
- } & Omit<SQFormStoryWrapperProps, 'initialValues' | 'children'>;
+  initialValues?: SQFormStoryWrapperProps['initialValues'];
+} & Omit<SQFormStoryWrapperProps, 'initialValues' | 'children'>;
 
 export type CustomStory<TComponentProps> = Story<
   Omit<TComponentProps, 'size'> & {
     size?: GridSizeOptions;
     sqFormProps?: FormProps;
-    schema: Record<string, AnySchema>;
+    schema: SQFormStoryWrapperProps['validationSchema'];
   }
->
+>;


### PR DESCRIPTION
SQForm components no only accept objects created with `Yup.object()` and
no longer accepts plain javascript objects

BREAKING CHANGE: 🧨 Plain javascript objects are no longer accepted for validation schema

Loom: https://www.loom.com/share/1459283335134f689166163ef83e75f8

✅ Closes: #316