### PR TITLE
fix: 🐛 Padding was being hard coded by scplus theme

### DIFF
--- a/src/components/SQFormScrollableCard/SQFormScrollableCard.tsx
+++ b/src/components/SQFormScrollableCard/SQFormScrollableCard.tsx
@@ -101,6 +101,7 @@ const useStyles = makeStyles((theme) => {
       gridArea: 'header',
       borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
       padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
+      height: 'auto', // overrides a scplus-shared-component theme hard coded height
     },
     cardContent: (props: useStylesProps) => ({
       gridArea: 'content',


### PR DESCRIPTION
Due to some theme changes in scplus shared components the height of the header was fixed to 48px. Given that we expect different title variants into SQFormScrollable card. This modifies the css class applied to the header over the theme and gives the header 'auto' for height. This looks to restore the previous padding behavior. 

I have listed this as a breaking change as it does change how the layout will work. However, if this is incorrect I am happy to modify / remake this PR. 

<img width="389" alt="image" src="https://user-images.githubusercontent.com/2816261/160836609-0496feb5-ec00-42a1-a4c6-b5cb7e8a9d9b.png">

<img width="652" alt="image" src="https://user-images.githubusercontent.com/2816261/160836678-ad342d01-34c7-462a-b660-2c5cb7632024.png">

Here is a loom of the issue when it is broken: https://www.loom.com/share/d051b256c278458cabf0eec76fbc6334
