### PR TITLE
Issue/653 card headers

### DIFF
--- a/src/components/SQFormScrollableCard/SQFormScrollableCard.tsx
+++ b/src/components/SQFormScrollableCard/SQFormScrollableCard.tsx
@@ -16,6 +16,7 @@ import SQFormButton from '../SQForm/SQFormButton';
 import SQFormHelperText from '../SQForm/SQFormHelperText';
 import {useInitialRequiredErrors} from '../../hooks/useInitialRequiredErrors';
 import {CreateCSSProperties} from '@material-ui/core/styles/withStyles';
+import {HEADER_HEIGHT} from '../../utils/constants';
 
 export interface SQFormScrollableCardProps<Values extends FormikValues> {
   /** An object of css-in-js style properties to be passed and spread onto `classes.cardContent` */
@@ -101,6 +102,7 @@ const useStyles = makeStyles((theme) => {
       gridArea: 'header',
       borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
       padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
+      height: HEADER_HEIGHT, // overrides a scplus-shared-component theme hard coded height
     },
     cardContent: (props: useStylesProps) => ({
       gridArea: 'content',
@@ -146,7 +148,6 @@ function SQFormScrollableCard<Values>({
   title,
   validationSchema,
   isHeaderDisabled = false,
-  titleVariant = 'h4',
   isSquareCorners = true,
 }: SQFormScrollableCardProps<Values>): React.ReactElement {
   const hasSubHeader = Boolean(SubHeaderComponent);
@@ -231,7 +232,7 @@ function SQFormScrollableCard<Values>({
                   <CardHeader
                     title={title}
                     className={classes.cardHeader}
-                    titleTypographyProps={{variant: titleVariant}}
+                    titleTypographyProps={{variant: 'h5'}}
                   />
                 )}
 

--- a/src/components/SQFormScrollableCardsMenuWrapper/SQFormScrollableCardsMenuWrapper.tsx
+++ b/src/components/SQFormScrollableCardsMenuWrapper/SQFormScrollableCardsMenuWrapper.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Card, CardHeader, makeStyles} from '@material-ui/core';
 import {CardPopoverMenu} from 'scplus-shared-components';
+import {HEADER_HEIGHT} from '../../utils/constants';
 
 const useStyles = makeStyles((theme) => {
   return {
@@ -15,13 +16,7 @@ const useStyles = makeStyles((theme) => {
       gridArea: 'header',
       borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
       padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
-      /**
-       * Have to do this because CardPopoverMenu adds a few extra
-       * pixels from a rogue span, which screws up alignment compared
-       * to normal SQFormScrollableCard headers or its more generic
-       * counterpart in MIAV, AdminViewCard.
-       */
-      height: '70px',
+      height: HEADER_HEIGHT, // overrides a scplus-shared-component theme hard coded height
       alignItems: 'center',
     },
     action: {
@@ -109,7 +104,7 @@ export default function SQFormScrollableCardsMenuWrapper({
         }}
         title={title}
         className={classes.cardHeader}
-        titleTypographyProps={{variant: 'h4'}}
+        titleTypographyProps={{variant: 'h5'}}
         action={
           <CardPopoverMenu
             tabs={menuItems}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,2 @@
 export const EMPTY_LABEL = '- -';
+export const HEADER_HEIGHT = '50px';

--- a/stories/SQFormScrollableCard.stories.tsx
+++ b/stories/SQFormScrollableCard.stories.tsx
@@ -131,13 +131,6 @@ WithStaticHeight.args = {
   SubHeaderComponent: <SubHeader />,
 };
 
-export const WithTitleVariant = Template.bind({});
-WithTitleVariant.args = {
-  ...defaultArgs,
-  title: 'h2 Title Variant',
-  titleVariant: 'h1',
-};
-
 export const WithRoundedCorners = Template.bind({});
 WithRoundedCorners.args = {
   ...defaultArgs,


### PR DESCRIPTION
Loom: https://www.loom.com/share/835f7225111f4006a775d3e43273da5c****

Breaking Changes: Removes the titleVariant prop from SQFormScrollableCard. Fixes the height of 
SQFormScrollableCard and SQFormScrollableCardsMenuWrapper to 50px.