### PR TITLE
refactor: 💡 SQFormGuidedWorkflow scriptedText accepts ReactNode

### DIFF
--- a/src/components/SQFormGuidedWorkflow/Types.ts
+++ b/src/components/SQFormGuidedWorkflow/Types.ts
@@ -34,7 +34,7 @@ export interface SQFormGuidedWorkflowAdditionalInformationProps
 export interface SQFormGuidedWorkflowAgentScriptProps
   extends SQFormGuidedWorkflowHeaderProps {
   /** Scripted Text for the user to read */
-  text: string;
+  text: React.ReactNode;
 }
 
 export interface SQFormGuidedWorkflowOutcomeProps

--- a/stories/SQFormGuidedWorkflow.stories.tsx
+++ b/stories/SQFormGuidedWorkflow.stories.tsx
@@ -48,11 +48,6 @@ const Template: CustomStory<
 > = (): React.ReactElement => {
   const [isIneligible, setIneligible] = React.useState(false);
   const [isModuleDisabled, setIsModuleDisabled] = React.useState(false);
-  const scriptedTextMap = {
-    customerName: 'Bob Smith',
-    agentName: 'Jane Doe',
-    planName: 'Super Cheap Med+',
-  };
   const initialValues = {
     outcome: '',
     notes: '',
@@ -102,7 +97,29 @@ const Template: CustomStory<
         infoText: 'This is suplmental information for the agent only.',
       },
       scriptedTextProps: {
-        text: `Hi, ${scriptedTextMap.customerName}, my name is ${scriptedTextMap.agentName}, and I am calling to discuss ${scriptedTextMap.planName}.\n Are you available right now to talk through some things with me, today?`,
+        text: (
+          <>
+            <Grid container>
+              <Grid item xs={12}>
+                Review the following ancillary benefits with the client
+              </Grid>
+              <Grid item xs={6}>
+                <ul style={{marginBottom: 0}}>
+                  <li>Dental (Reimbursement / Co-Pay)</li>
+                  <li>Transportation</li>
+                  <li>Home Health Care</li>
+                </ul>
+              </Grid>
+              <Grid item xs={6}>
+                <ul style={{marginBottom: 0}}>
+                  <li>Meals</li>
+                  <li>Fitness Membership</li>
+                  <li>Part B Giveback</li>
+                </ul>
+              </Grid>
+            </Grid>
+          </>
+        ),
         title: 'Agent Script',
       },
       outcomeProps: {
@@ -293,80 +310,81 @@ type InitialValuesType =
   | typeof firstSectionInitialValues
   | typeof secondSectionInitialValues;
 
-const TestTemplate: CustomStory<SQFormGuidedWorkflowProps<InitialValuesType>> =
-  (args): React.ReactElement => {
-    const {mainTitle, ...rest} = args;
+const TestTemplate: CustomStory<
+  SQFormGuidedWorkflowProps<InitialValuesType>
+> = (args): React.ReactElement => {
+  const {mainTitle, ...rest} = args;
 
-    const taskModules = [
-      {
-        name: 'firstSection',
-        title: 'First Section',
-        formikProps: {
-          initialValues: firstSectionInitialValues,
-          onSubmit: async (values: InitialValuesType) => {
-            console.log(JSON.stringify(values));
-          },
-          validationSchema: Yup.object({
-            firstText: Yup.string().required(),
-            secondText: Yup.string(),
-          }),
+  const taskModules = [
+    {
+      name: 'firstSection',
+      title: 'First Section',
+      formikProps: {
+        initialValues: firstSectionInitialValues,
+        onSubmit: async (values: InitialValuesType) => {
+          console.log(JSON.stringify(values));
         },
-        scriptedTextProps: {
-          text: 'This is some text',
-          title: 'Script Title',
-        },
-        outcomeProps: {
-          FormElements: (
-            <>
-              <SQFormTextField name="firstText" label="First Text" />
-              <SQFormTextField name="secondText" label="Second Text" />
-            </>
-          ),
-          title: 'Outcome Test',
+        validationSchema: Yup.object({
+          firstText: Yup.string().required(),
+          secondText: Yup.string(),
+        }),
+      },
+      scriptedTextProps: {
+        text: 'This is some text',
+        title: 'Script Title',
+      },
+      outcomeProps: {
+        FormElements: (
+          <>
+            <SQFormTextField name="firstText" label="First Text" />
+            <SQFormTextField name="secondText" label="Second Text" />
+          </>
+        ),
+        title: 'Outcome Test',
+      },
+    },
+    {
+      name: 'secondSection',
+      title: 'Second Section',
+      formikProps: {
+        initialValues: secondSectionInitialValues,
+        onSubmit: async (values: InitialValuesType) => {
+          console.log(JSON.stringify(values));
         },
       },
-      {
-        name: 'secondSection',
-        title: 'Second Section',
-        formikProps: {
-          initialValues: secondSectionInitialValues,
-          onSubmit: async (values: InitialValuesType) => {
-            console.log(JSON.stringify(values));
-          },
-        },
-        scriptedTextProps: {
-          text: 'This is some more text',
-          title: 'Another Script Title',
-        },
-        outcomeProps: {
-          FormElements: (
-            <>
-              <SQFormTextField name="testText" label="Test Text" />
-              <SQFormTextarea name="notes" label="Notes" />
-            </>
-          ),
-          title: 'Outcome Test',
-        },
+      scriptedTextProps: {
+        text: 'This is some more text',
+        title: 'Another Script Title',
       },
-    ];
+      outcomeProps: {
+        FormElements: (
+          <>
+            <SQFormTextField name="testText" label="Test Text" />
+            <SQFormTextarea name="notes" label="Notes" />
+          </>
+        ),
+        title: 'Outcome Test',
+      },
+    },
+  ];
 
-    return (
-      <div style={{width: '90%', height: '95vh'}}>
-        <ExpandingCardList>
-          <ExpandingCard title="Guided Workflow Test" name="guidedWorkflowTest">
-            <SQFormGuidedWorkflow<InitialValuesType>
-              {...rest}
-              mainTitle={mainTitle}
-              onError={(error) => {
-                console.error(error);
-              }}
-              taskModules={taskModules}
-            />
-          </ExpandingCard>
-        </ExpandingCardList>
-      </div>
-    );
-  };
+  return (
+    <div style={{width: '90%', height: '95vh'}}>
+      <ExpandingCardList>
+        <ExpandingCard title="Guided Workflow Test" name="guidedWorkflowTest">
+          <SQFormGuidedWorkflow<InitialValuesType>
+            {...rest}
+            mainTitle={mainTitle}
+            onError={(error) => {
+              console.error(error);
+            }}
+            taskModules={taskModules}
+          />
+        </ExpandingCard>
+      </ExpandingCardList>
+    </div>
+  );
+};
 
 export const Testing = TestTemplate.bind({});
 Testing.args = {

--- a/stories/__tests__/SQFormGuidedWorkflow.stories.test.tsx
+++ b/stories/__tests__/SQFormGuidedWorkflow.stories.test.tsx
@@ -78,7 +78,9 @@ describe('SQFormGuidedWorkflow Tests', () => {
   it('should close current expanded card and open the next one when next button is clicked', async () => {
     render(<SQFormGuidedWorkflow />);
 
-    const introText = screen.queryByText(/hi, bob smith, my name is/i);
+    const introText = screen.queryByText(
+      /Review the following ancillary benefits with the client/i
+    );
     expect(introText).toBeVisible();
 
     const policyText = screen.queryByText(/stuff about policy cancellation/i);
@@ -109,7 +111,9 @@ describe('SQFormGuidedWorkflow Tests', () => {
     jest.setTimeout(10000);
     render(<SQFormGuidedWorkflow />);
 
-    const introText = screen.getByText(/hi, bob smith, my name is/i);
+    const introText = screen.getByText(
+      /Review the following ancillary benefits with the client/i
+    );
     expect(introText).toBeVisible();
 
     const outcome = screen.getByRole('button', {name: /outcome/i});
@@ -137,11 +141,19 @@ describe('SQFormGuidedWorkflow Tests', () => {
 
     await waitFor(
       () =>
-        expect(screen.getByText(/hi, bob smith, my name is/i)).toBeVisible(),
+        expect(
+          screen.getByText(
+            /Review the following ancillary benefits with the client/i
+          )
+        ).toBeVisible(),
       {timeout: 2000}
     );
 
-    expect(screen.getByText(/hi, bob smith, my name is/i)).toBeVisible();
+    expect(
+      screen.getByText(
+        /Review the following ancillary benefits with the client/i
+      )
+    ).toBeVisible();
   });
 
   it('should display an error when in a failed state', async () => {


### PR DESCRIPTION
SQFormGuidedWorkflow scriptedText prop now accepts ReactNode instead of
just a string

Screenshot showing the use of this new type in Storybook below

![Screen Shot 2022-04-06 at 10 23 52 AM](https://user-images.githubusercontent.com/29528409/162011746-8029b294-43d9-4946-b24d-5862b11cd2d4.png)

✅ Closes: #658