### PR TITLE
fix: 🐛 Tests pass - changed react-text-mask types to a devDep

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ For **BREAKING CHANGES** Type a brief description of the breaking change when as
 
 ## Consuming
 
-This is a Typescript library and therefore relies on Typescript types from libraries other than this one. The libraries who's types SQForm relies on are marked as a [peer dependency](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#peerdependencies) if the library is also required for non-type imports. Otherwise, they're marked as an [optional dependency](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#optionaldependencies).
-
 By default in NPM v7 and above peer dependencies will be installed automatically. You can check your npm version using `npm --version` to determine the version you are using. If your version is not at least v7 you must install the peer dependencies manually.
 
 Optional dependencies are always installed but can be omitted by using `npm install --no-optional` when installing this package.
@@ -50,8 +48,10 @@ Optional dependencies are always installed but can be omitted by using `npm inst
   - `> npm install @selectquotelabs/sqform`
   - Install peer dependencies manually
 
-- To omit optional dependencies
-  - `> npm install @selectquotelabs/sqform --no-optional`
+- Using TypeScript
+  - `> npm install -D @types/react @types/react-dom @types/react-text-mask @types/yup`
+
+> Note: Ensure the types package major version number matches the package of your project. ex: React 16 should use v16 of @types/react
 
 ## Upgrading/Breaking Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6391,7 +6391,7 @@
       "version": "5.4.11",
       "resolved": "https://registry.npmjs.org/@types/react-text-mask/-/react-text-mask-5.4.11.tgz",
       "integrity": "sha512-DIJ3/dS4jd7NK3lEgsOwcgpp+ZlVrNJEiUDRayZRE/PNMbV/nLWmOKGdL0BUS29hnx0CDgITgPudKx0BgbF5fA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -97,9 +97,6 @@
     "react-dom": "^16.12.0",
     "yup": "^0.32.9"
   },
-  "optionalDependencies": {
-    "@types/react-text-mask": "^5.4.11"
-  },
   "devDependencies": {
     "@babel/core": "^7.11.4",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
@@ -136,6 +133,7 @@
     "@types/lodash.isequal": "^4.5.5",
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.4",
+    "@types/react-text-mask": "^5.4.11",
     "@types/react-window": "^1.8.5",
     "@types/testing-library__jest-dom": "^5.9.5",
     "@types/yup": "^0.29.11",


### PR DESCRIPTION
✅ Closes: #666

Consuming TS projects are always responsible for managing their types. Updated the readme to include our recommended types packages to install.

Screenshot shows all tests now pass

![Screen Shot 2022-04-11 at 9 18 58 AM](https://user-images.githubusercontent.com/4367312/162760713-963bebce-b50b-4027-abba-a26afc222bf1.png)

