### PR TITLE
fix: 🐛 field array valication bug

### DIFF
--- a/src/components/SQForm/useForm.tsx
+++ b/src/components/SQForm/useForm.tsx
@@ -78,7 +78,9 @@ export function useForm<TValue, TChangeEvent>({
   const isDirty = !isEqual(meta.initialValue, meta.value);
   const hasValue = _getHasValue(meta);
   const isError = !!errorMessage;
-  const isRequired = errorMessage?.toLowerCase() === 'required';
+  const isRequired = Array.isArray(errorMessage)
+    ? errorMessage.toString().toLowerCase() === 'required'
+    : errorMessage?.toLowerCase() === 'required';
 
   const getFieldStatus = () => {
     if (isRequired && !hasValue && !isDirty && !isTouched) {


### PR DESCRIPTION
fix bug that was caused by our validation errorMessage being converted
to an array when we are expecting a string.

here's a loom with my findings and a bit of info about the PR https://www.loom.com/share/a475ddc9e30e44dfb331baa78b306531


✅ Closes: 563