### PR TITLE
feat: 🎸 SQFormRadioButtonGroup accepts React Element child arr

### DIFF
--- a/src/components/SQForm/SQFormRadioButtonGroup.tsx
+++ b/src/components/SQForm/SQFormRadioButtonGroup.tsx
@@ -44,7 +44,7 @@ function SQFormRadioButtonGroup({
   const {
     fieldState: {isFieldError, isFieldRequired},
     formikField: {field},
-    fieldHelpers: {handleChange, HelperTextComponent},
+    fieldHelpers: {handleChange, handleBlur, HelperTextComponent},
   } = useForm<string | boolean | number, React.ChangeEvent<HTMLInputElement>>({
     name,
     onChange,
@@ -77,6 +77,7 @@ function SQFormRadioButtonGroup({
         component="fieldset"
         required={isFieldRequired}
         error={isFieldError}
+        onBlur={handleBlur}
       >
         <FormLabel
           component="legend"

--- a/src/components/SQForm/SQFormRadioButtonGroup.tsx
+++ b/src/components/SQForm/SQFormRadioButtonGroup.tsx
@@ -10,12 +10,13 @@ import SQFormRadioButtonGroupItem from './SQFormRadioButtonGroupItem';
 import {useForm} from './useForm';
 import type {GridSize, RadioProps, RadioGroupProps} from '@material-ui/core';
 
-type RadioButtonInputItemProps = {
+type RadioButtonConfigListItem = {
   value: string | boolean | number;
   label: string;
   isDisabled?: boolean;
   InputProps?: RadioProps;
 };
+type RadioButtonGroupChild = React.ReactElement | RadioButtonConfigListItem;
 
 export type SQFormRadioButtonGroupProps = {
   /** Name of the Radio Group */
@@ -28,8 +29,8 @@ export type SQFormRadioButtonGroupProps = {
   shouldDisplayInRow?: boolean;
   /** Label to display above the group */
   groupLabel: string;
-  /** Children must be an array of objects with radio button label and value information */
-  children: RadioButtonInputItemProps[];
+  /** Children must be 1) an array of objects with radio button label and value information OR 2) an array of SQFormRadioButtonGroupItem components, each with `label` and `value` props  */
+  children: Array<RadioButtonGroupChild>;
 };
 
 function SQFormRadioButtonGroup({
@@ -43,18 +44,20 @@ function SQFormRadioButtonGroup({
   const {
     fieldState: {isFieldError, isFieldRequired},
     formikField: {field},
-    fieldHelpers: {handleChange, handleBlur, HelperTextComponent},
-  } = useForm<
-    RadioButtonInputItemProps['value'],
-    React.ChangeEvent<HTMLInputElement>
-  >({
+    fieldHelpers: {handleChange, HelperTextComponent},
+  } = useForm<string | boolean | number, React.ChangeEvent<HTMLInputElement>>({
     name,
     onChange,
   });
 
   const childrenToRadioGroupItems = () => {
+    if (children.every((item) => React.isValidElement(item))) {
+      return children;
+    }
+
     return children.map((radioOption) => {
-      const {label, value, isDisabled, InputProps} = radioOption;
+      const {label, value, isDisabled, InputProps} =
+        radioOption as RadioButtonConfigListItem;
       return (
         <SQFormRadioButtonGroupItem
           label={label}
@@ -74,7 +77,6 @@ function SQFormRadioButtonGroup({
         component="fieldset"
         required={isFieldRequired}
         error={isFieldError}
-        onBlur={handleBlur}
       >
         <FormLabel
           component="legend"

--- a/stories/SQFormRadioButtonGroup.stories.tsx
+++ b/stories/SQFormRadioButtonGroup.stories.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import * as Yup from 'yup';
 
-import {SQFormRadioButtonGroup as SQFormRadioButtonGroupComponent} from '../src';
+import {
+  SQFormRadioButtonGroup as SQFormRadioButtonGroupComponent,
+  SQFormRadioButtonGroupItem,
+  SQFormTextField,
+} from '../src';
 import getSizeProp from './utils/getSizeProp';
 import {createDocsPage} from './utils/createDocsPage';
 import {
@@ -81,5 +85,39 @@ WithValidation.args = {
   }),
 };
 WithValidation.parameters = {
+  controls: {exclude: 'schema'},
+};
+
+const withElementChildren: RadioButtonGroupType = (args) => {
+  const {sqFormProps, schema, size, ...componentProps} = args;
+  return (
+    <SQFormStoryWrapper
+      {...defaultArgs.sqFormProps}
+      {...sqFormProps}
+      validationSchema={schema}
+    >
+      <SQFormRadioButtonGroupComponent
+        {...componentProps}
+        size={getSizeProp(size)}
+      >
+        <SQFormRadioButtonGroupItem label="Giant Panda" value="giant panda" />
+        <SQFormRadioButtonGroupItem label="Red Panda" value="red panda" />
+        <SQFormTextField label="thing" name="whatever" />
+        <SQFormRadioButtonGroupItem
+          label="Kung Fu Panda"
+          value="kung fu panda"
+        />
+      </SQFormRadioButtonGroupComponent>
+    </SQFormStoryWrapper>
+  );
+};
+export const WithElementChildren = withElementChildren.bind({});
+WithElementChildren.args = {
+  ...defaultArgs,
+  schema: Yup.object({
+    [defaultArgs.name]: Yup.string(),
+  }),
+};
+WithElementChildren.parameters = {
   controls: {exclude: 'schema'},
 };


### PR DESCRIPTION
SQFormRadioButtonGroup accepts children in shape of array of React
Elements

✅ Closes: #693

[Loom demo](https://www.loom.com/share/70a3d9175fb2441796db5ac78165f878)

This addresses an issue originating [from AQE2](https://selectquote.atlassian.net/browse/AQE2-1084)