### PR TITLE
fix: 🐛 Fixed issue with how SQFormHelperText chose type

### DIFF
--- a/src/components/SQFormDialog/SQFormDialogInner.tsx
+++ b/src/components/SQFormDialog/SQFormDialogInner.tsx
@@ -247,7 +247,7 @@ function SQFormDialogInner<Values extends FormikValues>({
       default:
         return (
           <Grid item={true}>
-            <SQFormHelperText errorText={helperText} />
+            <SQFormHelperText isValidState={false} errorText={helperText} />
           </Grid>
         );
     }


### PR DESCRIPTION
Ariel discovered an issue with how the SQFormHelperText was working with the new `isValidState` prop.  This small PR fixes that.

https://www.loom.com/share/e9a7a21eae3142869ae6911d5a6bed8c
