### PR TITLE
refactor: 💡 Migrate MaskedTextField to MUI5

### DIFF
--- a/stories/SQFormMaskedReadOnlyField.stories.tsx
+++ b/stories/SQFormMaskedReadOnlyField.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import getSizeProp from './utils/getSizeProp';
+import getSizeProp from '../old_stories/utils/getSizeProp';
 import {
   MASKS,
   SQFormMaskedReadOnlyField as SQFormMaskedReadOnlyFieldComponent,
 } from '../src';
-import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
-import {createDocsPage} from './utils/createDocsPage';
+import {SQFormStoryWrapper} from '../old_stories/components/SQFormStoryWrapper';
+import {createDocsPage} from '../old_stories/utils/createDocsPage';
 import type {Meta} from '@storybook/react';
-import type {CustomStory} from './types/storyHelperTypes';
+import type {CustomStory} from '../old_stories/types/storyHelperTypes';
 import type {Mask} from 'types';
 import type {SQFormMaskedReadOnlyFieldProps} from '../src/components/SQForm/SQFormMaskedReadOnlyField';
 

--- a/stories/SQFormMaskedTextField.stories.tsx
+++ b/stories/SQFormMaskedTextField.stories.tsx
@@ -4,13 +4,13 @@ import {
   MASKS,
   SQFormMaskedTextField as SQFormMaskedTextFieldComponent,
 } from '../src';
-import getSizeProp from './utils/getSizeProp';
-import {createDocsPage} from './utils/createDocsPage';
-import {SQFormStoryWrapper} from './components/SQFormStoryWrapper';
-import type {SQFormStoryWrapperProps} from './components/SQFormStoryWrapper';
+import getSizeProp from '../old_stories/utils/getSizeProp';
+import {createDocsPage} from '../old_stories/utils/createDocsPage';
+import {SQFormStoryWrapper} from '../old_stories/components/SQFormStoryWrapper';
+import type {SQFormStoryWrapperProps} from '../old_stories/components/SQFormStoryWrapper';
 import type {Story} from '@storybook/react';
 import type {SQFormMaskedTextFieldProps} from 'components/SQForm/SQFormMaskedTextField';
-import type {GridSizeOptions} from './types/storyHelperTypes';
+import type {GridSizeOptions} from '../old_stories/types/storyHelperTypes';
 import type {Mask} from 'types';
 
 export default {


### PR DESCRIPTION
https://www.loom.com/share/8b6237794aaf443082143966493c62da

Migrates `SQFormMaskedTextField` and `SQFormmaskedReadOnlyField`.

✅ Closes: #732