### PR TITLE
feat: 🎸 Adds icon prop to scrollable card

### DIFF
--- a/src/components/SQFormScrollableCard/SQFormScrollableCard.tsx
+++ b/src/components/SQFormScrollableCard/SQFormScrollableCard.tsx
@@ -78,6 +78,8 @@ export type SQFormScrollableCardProps<Values extends FormikValues> = {
   titleVariant?: TypographyVariant;
   /** Boolean used to determine if the corners of the card should be squared */
   isSquareCorners?: boolean;
+  /** An Icon to be shown to the left of the title */
+  icon?: React.ReactNode;
 };
 
 type useStylesProps = {
@@ -149,6 +151,7 @@ function SQFormScrollableCard<Values>({
   validationSchema,
   isHeaderDisabled = false,
   isSquareCorners = true,
+  icon,
 }: SQFormScrollableCardProps<Values>): React.ReactElement {
   const hasSubHeader = Boolean(SubHeaderComponent);
 
@@ -233,6 +236,7 @@ function SQFormScrollableCard<Values>({
                     title={title}
                     className={classes.cardHeader}
                     titleTypographyProps={{variant: 'h5'}}
+                    avatar={icon}
                   />
                 )}
 

--- a/stories/SQFormScrollableCard.stories.tsx
+++ b/stories/SQFormScrollableCard.stories.tsx
@@ -2,6 +2,7 @@ import * as Yup from 'yup';
 import React from 'react';
 
 import {Paper} from '@material-ui/core';
+import {Public} from '@material-ui/icons';
 import {SQFormScrollableCard, SQFormTextField} from '../src';
 import {createDocsPage} from './utils/createDocsPage';
 import type {GridProps} from '@material-ui/core';
@@ -136,4 +137,11 @@ WithRoundedCorners.args = {
   ...defaultArgs,
   title: 'With Rounded Corners',
   isSquareCorners: false,
+};
+
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  ...defaultArgs,
+  title: 'With Icon',
+  icon: <Public fontSize="large" />,
 };


### PR DESCRIPTION
Provides and optional icon prop to supply the scrollable card an icon to
place to the left of the title.

✅ Closes: 744

 https://www.loom.com/share/ce72e1c67e404ea4981e113bd4069120