### PR TITLE
chore: 🤖 Fix failing storybook deployment

### DIFF
--- a/.github/workflows/Storybook.yml
+++ b/.github/workflows/Storybook.yml
@@ -14,8 +14,11 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: '12'
-      - run: |
-          npm ci && npm run build-storybook
+      - run: cd ./SQFormDocs
+      - run: npm ci
+      - run: cd ..
+      - run: npm ci
+      - run: npm run build-storybook
       - uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Storybook deployment was failing. It looks like, based on the erorrs, that it was unable to find node_modules in the SQFormDocs directory. Not sure why this is happening all the sudden. 

Between all our actions I wasn't able to find a place where the SQFormDocs node_modules were being installed. so I added that to the storybook action and hopefully that'll fix it.

I was able to reproduce the same issue locally by removing my local ./SQFormDocs/node_modules and trying to run `npm run build-storybook`. Doing so gave me the same error locally we were seeing on the Pipeline. After reinstalling node_modules it passed. So trying this out 🤷 