### PR TITLE
chore: 🤖 Fix installation of node_modules in SQFormDocs

### DIFF
--- a/.github/workflows/Storybook.yml
+++ b/.github/workflows/Storybook.yml
@@ -14,9 +14,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: '12'
-      - run: cd ./SQFormDocs
-      - run: npm ci
-      - run: cd ..
+      - run: npm --prefix ./SQFormDocs/ ci # Installs node_modules in SQFormDocs directory as well
       - run: npm ci
       - run: npm run build-storybook
       - uses: chromaui/action@v1


### PR DESCRIPTION
Turns out you can't use `cd` in the pipeline but we can use the --prefix flag to install them without needing to be in that directory.