### PR TITLE
chore: 🤖 Update HelperText styles

### DIFF
--- a/.storybook/styles/AgGrid.css
+++ b/.storybook/styles/AgGrid.css
@@ -1,11 +1,17 @@
 /* ag-grid theme override css */
 .ag-header-cell {
   font-size: 12px;
-  background-color: var(--color-stone);
+  background-color: var(--color-rock);
   color: var(--color-white);
   width: auto;
   font-family: 'Open Sans';
   font-weight: 400;
+  padding-left: 10px !important;
+  padding-right: 10px !important;
+}
+
+.ag-header-cell::after {
+  border-right: 1px solid #a4a6a8 !important;
 }
 
 .ag-theme-balham .ag-row-hover {
@@ -73,12 +79,14 @@
 }
 
 .ag-header {
-  background-color: var(--color-stone) !important;
+  background-color: var(--color-rock) !important;
 }
 
 .columnList__hyperlink {
-  color: var(--color-teal);
+  color: var(--color-darkTeal);
   cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
 }
 
 .columnList__number {
@@ -100,4 +108,8 @@
 
 .dataTable__number {
   text-align: right;
+}
+
+.ag-theme-balham .ag-paging-panel {
+  height: 34px;
 }

--- a/.storybook/styles/fonts.css
+++ b/.storybook/styles/fonts.css
@@ -1,0 +1,32 @@
+/* open-sans-300 - latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Open Sans Light'), local('OpenSans-Light'),
+    url('./Open_Sans/OpenSans-Light.ttf');
+}
+/* open-sans-400 - latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'),
+    url('./Open_Sans/OpenSans-Regular.ttf');
+}
+/* open-sans-600 - latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Open Sans SemiBold'), local('OpenSans-SemiBold'),
+    url('./Open_Sans/OpenSans-SemiBold.ttf');
+}
+/* open-sans-700 - latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'),
+    url('./Open_Sans/OpenSans-Bold.ttf');
+}

--- a/.storybook/styles/index.css
+++ b/.storybook/styles/index.css
@@ -1,6 +1,6 @@
+@import './fonts.css';
 @import './root.css';
 @import './animations.css';
 @import './typography.css';
 @import './utilClasses.css';
 @import './AgGrid.css';
-@import './storybook.css';

--- a/.storybook/styles/root.css
+++ b/.storybook/styles/root.css
@@ -6,18 +6,19 @@
   --color-recruitViolet: #432534;
   --color-srtsGreen: #5a7e44;
   --color-teal: #017788;
-  --color-lightTeal: #34a1b6;
   --color-darkTeal: #004b5b;
+  --color-lightTeal: #34a1b6;
   --color-frenchBleu: #0066ff;
   --color-oysterBay: #d9f1f4;
   --color-lightBlue: #ecf5f7;
   --color-orange: #f17c21;
   --color-granite: #5b5858;
 
-  --color-textSuccessGreen: #3C7107;
-  --color-textWarningYellow: #C67000;
-  --color-textErrorRed: #AD0010;
-  --color-textInfoBlue: #006CCB;
+  --color-textSuccessGreen: #3c7107;
+  --color-textWarningYellow: #c67000;
+  --color-textErrorRed: #ad0010;
+  --color-textInfoBlue: #006ccb;
+  --color-textDisabled: #9e9e9e;
 
   --color-brightYellow: #ff9f1c;
   --color-sienna: #c46c2a;
@@ -33,6 +34,7 @@
   --color-white: #ffffff;
 
   --color-stone: #8a8889;
+  --color-rock: #767676;
   --color-slate: #b3b4b3;
   --color-concrete: #b8b2a9;
   --color-gainsboro: #e0e0e0;

--- a/src/components/SQForm/useForm.tsx
+++ b/src/components/SQForm/useForm.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import isEqual from 'lodash.isequal';
 import {getIn, useField} from 'formik';
+import {Typography} from '@mui/material';
 import {
   NewReleases as WarningIcon,
   VerifiedUser as VerifiedIcon,
 } from '@mui/icons-material';
+import type {Theme} from '@mui/material';
 import type {FieldHelperProps, FieldInputProps, FieldMetaProps} from 'formik';
 
 type ChangeHandler<TChangeEvent> = (
@@ -40,6 +42,11 @@ type UseFormReturn<TValue, TChangeEvent> = {
 };
 
 const SPACE_STYLE = {marginRight: '0.3333rem'};
+const ICON_STYLES = {
+  ...SPACE_STYLE,
+  width: '12px',
+  height: '11px',
+};
 
 function _handleError(name: string) {
   if (typeof name !== 'string') {
@@ -128,24 +135,26 @@ export function useForm<TValue, TChangeEvent>({
     if (isFieldError) {
       return (
         <>
-          <WarningIcon color="error" style={SPACE_STYLE} />
-          {errorMessage}
+          <WarningIcon color="error" sx={ICON_STYLES} />
+          <Typography sx={(theme: Theme) => theme.typography.helper}>
+            {errorMessage}
+          </Typography>
         </>
       );
     }
     if (isFieldRequired) {
       return (
         <>
-          <WarningIcon color="disabled" style={SPACE_STYLE} />
-          Required
+          <WarningIcon color="disabled" sx={ICON_STYLES} />
+          <Typography sx={(theme: Theme) => theme.typography.helper}>
+            Required
+          </Typography>
         </>
       );
     }
     if (isFulfilled) {
       return (
-        <VerifiedIcon
-          style={{color: 'var(--color-palmLeaf)', ...SPACE_STYLE}}
-        />
+        <VerifiedIcon sx={{color: 'var(--color-palmLeaf)', ...ICON_STYLES}} />
       );
     }
     return ' '; // return something so UI space always exists

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -1,0 +1,10 @@
+import type {CSSProperties} from '@mui/styles';
+
+// Let the MUI theme type use these extra typography properties
+// Can expand upon as needed
+// Should hopefully be done in SSC eventually
+declare module '@mui/material/styles/createTypography' {
+  export interface Typography {
+    helper: CSSProperties;
+  }
+}

--- a/stories/SQFormTextField.stories.tsx
+++ b/stories/SQFormTextField.stories.tsx
@@ -58,7 +58,9 @@ WithValidation.args = {
   ...defaultArgs,
   SQFormProps: {
     validationSchema: Yup.object({
-      [defaultArgs.name]: Yup.string().required('Required'),
+      [defaultArgs.name]: Yup.string()
+        .required('Required')
+        .min(3, 'Minimum 3 characters'),
     }),
   },
 };

--- a/stories/__tests__/SQFormAsyncAutocomplete.stories.test.tsx
+++ b/stories/__tests__/SQFormAsyncAutocomplete.stories.test.tsx
@@ -167,12 +167,14 @@ describe('SQFormAsyncAutocomplete Tests', () => {
 
   describe('Autocomplete With Validation', () => {
     it('should render as required when it is a required field', async () => {
-      render(<SQFormAsyncAutocompleteWithValidation size="auto" />);
+      const {container} = render(
+        <SQFormAsyncAutocompleteWithValidation size="auto" />
+      );
 
       await waitFor(() => {
-        const requiredText = screen.getByText(/required/i);
-        expect(requiredText).toBeVisible();
-        expect(requiredText).toHaveClass('Mui-required');
+        const helperText = container.querySelector('.MuiFormHelperText-root');
+        expect(helperText).toBeVisible();
+        expect(helperText).toHaveClass('Mui-required');
       });
     });
 
@@ -184,7 +186,9 @@ describe('SQFormAsyncAutocomplete Tests', () => {
     });
 
     it('should highlight field if required but no value selected', async () => {
-      render(<SQFormAsyncAutocompleteWithValidation size="auto" />);
+      const {container} = render(
+        <SQFormAsyncAutocompleteWithValidation size="auto" />
+      );
 
       const textField = screen.getByRole('combobox', {
         name: /async autocomplete/i,
@@ -197,9 +201,9 @@ describe('SQFormAsyncAutocomplete Tests', () => {
       userEvent.tab();
 
       await waitFor(() => {
-        const requiredText = screen.getByText(/required/i);
-        expect(requiredText).toBeVisible();
-        expect(requiredText).toHaveClass('Mui-error');
+        const helperText = container.querySelector('.MuiFormHelperText-root');
+        expect(helperText).toBeVisible();
+        expect(helperText).toHaveClass('Mui-error');
       });
     });
   });

--- a/stories/__tests__/SQFormAutocomplete.stories.test.tsx
+++ b/stories/__tests__/SQFormAutocomplete.stories.test.tsx
@@ -150,12 +150,14 @@ describe('SQFormAutocomplete Tests', () => {
 
   describe('Autocomplete With Validation', () => {
     it('should render as required when it is a required field', async () => {
-      render(<SQFormAutocompleteWithValidation size="auto" />);
+      const {container} = render(
+        <SQFormAutocompleteWithValidation size="auto" />
+      );
 
       await waitFor(() => {
-        const requiredText = screen.getByText(/required/i);
-        expect(requiredText).toBeVisible();
-        expect(requiredText).toHaveClass('Mui-required');
+        const helperText = container.querySelector('.MuiFormHelperText-root');
+        expect(helperText).toBeVisible();
+        expect(helperText).toHaveClass('Mui-required');
       });
     });
 
@@ -167,7 +169,9 @@ describe('SQFormAutocomplete Tests', () => {
     });
 
     it('should highlight field if required but no value selected', async () => {
-      render(<SQFormAutocompleteWithValidation size="auto" />);
+      const {container} = render(
+        <SQFormAutocompleteWithValidation size="auto" />
+      );
 
       const textField = screen.getByRole('combobox', {name: /autocomplete/i});
       expect(textField).not.toHaveFocus();
@@ -178,9 +182,9 @@ describe('SQFormAutocomplete Tests', () => {
       userEvent.tab();
 
       await waitFor(() => {
-        const requiredText = screen.getByText(/required/i);
-        expect(requiredText).toBeVisible();
-        expect(requiredText).toHaveClass('Mui-error');
+        const helperText = container.querySelector('.MuiFormHelperText-root');
+        expect(helperText).toBeVisible();
+        expect(helperText).toHaveClass('Mui-error');
       });
     });
   });

--- a/stories/__tests__/SQFormCheckboxGroup.stories.test.tsx
+++ b/stories/__tests__/SQFormCheckboxGroup.stories.test.tsx
@@ -217,12 +217,14 @@ describe('SQFormCheckboxGroup Tests', () => {
     });
 
     it('should render "required" text when when its field is required', async () => {
-      render(<SQFormCheckboxGroupWithValidation size="auto" />);
+      const {container} = render(
+        <SQFormCheckboxGroupWithValidation size="auto" />
+      );
 
       await waitFor(() => {
-        const requiredText = screen.getByText(/required/i);
-        expect(requiredText).toBeInTheDocument();
-        expect(requiredText).toHaveClass('Mui-required');
+        const helperText = container.querySelector('.MuiFormHelperText-root');
+        expect(helperText).toBeInTheDocument();
+        expect(helperText).toHaveClass('Mui-required');
       });
     });
 

--- a/stories/__tests__/SQFormDatePicker.stories.test.tsx
+++ b/stories/__tests__/SQFormDatePicker.stories.test.tsx
@@ -19,7 +19,7 @@ const renderDatePicker = (
     }
   >
 ) => {
-  render(
+  return render(
     <LocalizationProvider dateAdapter={AdapterMoment} locale={'en'}>
       <BasicDatePicker {...props} />
     </LocalizationProvider>
@@ -135,11 +135,11 @@ describe('SQFormDatePicker Tests', () => {
       },
     };
 
-    renderDatePicker({sqFormProps});
+    const {container} = renderDatePicker({sqFormProps});
     await waitFor(() => {
-      const requiredText = screen.getByText(/required/i);
-      expect(requiredText).toBeVisible();
-      expect(requiredText).toHaveClass('Mui-required');
+      const helperText = container.querySelector('.MuiFormHelperText-root');
+      expect(helperText).toBeVisible();
+      expect(helperText).toHaveClass('Mui-required');
     });
   });
 });

--- a/stories/__tests__/SQFormDatePickerWithDateFNS.stories.test.tsx
+++ b/stories/__tests__/SQFormDatePickerWithDateFNS.stories.test.tsx
@@ -20,7 +20,7 @@ const renderDatePicker = (
     }
   >
 ) => {
-  render(
+  return render(
     <LocalizationProvider dateAdapter={AdapterDateFns} locale={enLocale}>
       <BasicDatePicker {...props} />
     </LocalizationProvider>
@@ -136,11 +136,11 @@ describe('SQFormDatePickerWithDateFNS Tests', () => {
       },
     };
 
-    renderDatePicker({sqFormProps});
+    const {container} = renderDatePicker({sqFormProps});
     await waitFor(() => {
-      const requiredText = screen.getByText(/required/i);
-      expect(requiredText).toBeVisible();
-      expect(requiredText).toHaveClass('Mui-required');
+      const helperText = container.querySelector('.MuiFormHelperText-root');
+      expect(helperText).toBeVisible();
+      expect(helperText).toHaveClass('Mui-required');
     });
   });
 });

--- a/stories/__tests__/SQFormDropdown.stories.test.tsx
+++ b/stories/__tests__/SQFormDropdown.stories.test.tsx
@@ -147,7 +147,9 @@ it('should highlight field if required but no value selected', async () => {
     initialValues: {state: ''},
   };
 
-  render(<SQFormDropdown sqFormProps={formProps} size="auto" />);
+  const {container} = render(
+    <SQFormDropdown sqFormProps={formProps} size="auto" />
+  );
 
   const expandButton = screen.getByRole('button', {name: /state/i});
 
@@ -157,9 +159,9 @@ it('should highlight field if required but no value selected', async () => {
   userEvent.tab();
   await waitFor(() => expect(expandButton).not.toHaveFocus());
 
-  const required = screen.getByText(/required/i);
-  expect(required).toBeVisible();
-  expect(required).toHaveClass('Mui-error');
+  const helperText = container.querySelector('.MuiFormHelperText-root');
+  expect(helperText).toBeVisible();
+  expect(helperText).toHaveClass('Mui-error');
 });
 
 it('should show empty list if no options are given', () => {

--- a/stories/__tests__/SQFormRadioButtonGroup.stories.test.tsx
+++ b/stories/__tests__/SQFormRadioButtonGroup.stories.test.tsx
@@ -136,19 +136,23 @@ describe('SQFormRadioButtonGroup Tests', () => {
       });
 
       it('displays required helper text', async () => {
-        render(<SQFormRadioButtonGroupWithValidation size="auto" />);
+        const {container} = render(
+          <SQFormRadioButtonGroupWithValidation size="auto" />
+        );
 
         await waitFor(() => {
-          const requiredText = screen.getByText('Required');
-          expect(requiredText).toBeInTheDocument();
-          expect(requiredText).toHaveClass('Mui-required');
+          const helperText = container.querySelector('.MuiFormHelperText-root');
+          expect(helperText).toBeInTheDocument();
+          expect(helperText).toHaveClass('Mui-required');
         });
       });
     });
 
     describe('touched and no value selected', () => {
       it('has error styles on label and helper text', async () => {
-        render(<SQFormRadioButtonGroupWithValidation size="auto" />);
+        const {container} = render(
+          <SQFormRadioButtonGroupWithValidation size="auto" />
+        );
 
         // Tab into radio group
         userEvent.tab();
@@ -157,9 +161,9 @@ describe('SQFormRadioButtonGroup Tests', () => {
         userEvent.tab();
         await waitFor(() => {
           const label = screen.getByText(/Pandas/i);
-          const requiredText = screen.getByText(/Required/i);
+          const helperText = container.querySelector('.MuiFormHelperText-root');
           expect(label).toHaveClass('Mui-error');
-          expect(requiredText).toHaveClass('Mui-error');
+          expect(helperText).toHaveClass('Mui-error');
         });
       });
     });

--- a/stories/__tests__/SQFormTextField.stories.test.tsx
+++ b/stories/__tests__/SQFormTextField.stories.test.tsx
@@ -96,15 +96,15 @@ describe('SQFormTextField Tests', () => {
 
   describe('Text Field With Validation', () => {
     it('should initially render "Required" helper text if field is required', async () => {
-      render(<SQFormTextFieldWithValidation size="auto" />);
+      const {container} = render(<SQFormTextFieldWithValidation size="auto" />);
 
-      await waitFor(() =>
-        expect(screen.getByText(/required/i)).toHaveClass('Mui-required')
-      );
+      const helperText = container.querySelector('.MuiFormHelperText-root');
+
+      await waitFor(() => expect(helperText).toHaveClass('Mui-required'));
     });
 
     it('should highlight field if required but no value selected', async () => {
-      render(<SQFormTextFieldWithValidation size="auto" />);
+      const {container} = render(<SQFormTextFieldWithValidation size="auto" />);
 
       userEvent.tab();
 
@@ -114,9 +114,10 @@ describe('SQFormTextField Tests', () => {
       userEvent.tab();
       expect(textField).not.toHaveFocus();
 
-      await waitFor(() =>
-        expect(screen.getByText('Required')).toHaveClass('Mui-error')
-      );
+      await waitFor(() => {
+        const helperText = container.querySelector('.MuiFormHelperText-root');
+        expect(helperText).toHaveClass('Mui-error');
+      });
     });
   });
 });

--- a/stories/__tests__/SQFormTextarea.stories.test.tsx
+++ b/stories/__tests__/SQFormTextarea.stories.test.tsx
@@ -100,15 +100,14 @@ describe('SQFormTextarea Tests', () => {
 
   describe('Textarea With Validation', () => {
     it('should initially render "Required" helper text if field is required', async () => {
-      render(<SQFormTextareaWithValidation size="auto" />);
+      const {container} = render(<SQFormTextareaWithValidation size="auto" />);
+      const helperText = container.querySelector('.MuiFormHelperText-root');
 
-      await waitFor(() =>
-        expect(screen.getByText('Required')).toHaveClass('Mui-required')
-      );
+      await waitFor(() => expect(helperText).toHaveClass('Mui-required'));
     });
 
     it('should highlight field if required by no value selected', async () => {
-      render(<SQFormTextareaWithValidation size="auto" />);
+      const {container} = render(<SQFormTextareaWithValidation size="auto" />);
 
       userEvent.tab();
 
@@ -118,9 +117,10 @@ describe('SQFormTextarea Tests', () => {
       userEvent.tab();
       expect(textbox).not.toHaveFocus();
 
-      await waitFor(() =>
-        expect(screen.getByText('Required')).toHaveClass('Mui-error')
-      );
+      await waitFor(() => {
+        const helperText = container.querySelector('.MuiFormHelperText-root');
+        expect(helperText).toHaveClass('Mui-error');
+      });
     });
   });
 });


### PR DESCRIPTION
Update HelperText styles to utilize the new MUIv5 theme from SSC

✅ Closes: #779

For all screenshots - New on left, old on right
<img width="1155" alt="Screen Shot 2022-08-16 at 1 00 16 PM" src="https://user-images.githubusercontent.com/29528409/184979137-055cc5e9-69ba-4567-b229-264815a63a91.png">
<img width="1164" alt="Screen Shot 2022-08-16 at 1 00 06 PM" src="https://user-images.githubusercontent.com/29528409/184979140-3fdcd387-bff4-4b75-86ca-c7172fa42b73.png">
<img width="955" alt="Screen Shot 2022-08-16 at 12 58 03 PM" src="https://user-images.githubusercontent.com/29528409/184979142-28c224f3-4339-441e-b60a-b9284a50681b.png">
<img width="988" alt="Screen Shot 2022-08-16 at 12 57 55 PM" src="https://user-images.githubusercontent.com/29528409/184979147-6e705afa-06c9-4425-a971-7cd77e8ca359.png">

