### PR TITLE
fix: 🐛 SQFormDialogStepper validation works properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,13 @@ Optional dependencies are always installed but can be omitted by using `npm inst
 ### Version [MUIv5]
 
 - SQFormTextarea
+
   - Renamed `rows` to `minRows`
   - Renamed `rowsMax` to `maxRows`
+
+- SQFormDialogStepper
+  - SQFormDialogStepper now validates on mount
+  - Previously the Next/Submit button was disabled if not all fields had a value, regardless of validation schema. We've updated this component it not care about each individual field's value and instead only take into account the validation schema, the dirty status, and `isDisabled` prop
 
 ### Version 8
 

--- a/src/components/SQFormDialogStepper/SQFormDialogStepper.tsx
+++ b/src/components/SQFormDialogStepper/SQFormDialogStepper.tsx
@@ -190,8 +190,7 @@ export function SQFormDialogStepper<Values extends FormikValues>({
   };
 
   function SubmitButton() {
-    const {errors, values, dirty} = useFormikContext<Record<string, unknown>>();
-
+    const {errors, dirty} = useFormikContext<Record<string, unknown>>();
     const isButtonDisabled = React.useMemo(() => {
       if (isNextDisabled) {
         return true;
@@ -200,12 +199,8 @@ export function SQFormDialogStepper<Values extends FormikValues>({
         return false;
       }
       const currentStepKeys = Object.keys(validationSchema.fields);
-      const stepValues = currentStepKeys.every((step) => {
-        return !!values[step];
-      });
 
       if (
-        !stepValues ||
         currentStepKeys.some((step) => Object.keys(errors).includes(step)) ||
         !dirty
       ) {
@@ -213,7 +208,7 @@ export function SQFormDialogStepper<Values extends FormikValues>({
       }
 
       return false;
-    }, [errors, values, dirty]);
+    }, [errors, dirty]);
 
     const primaryButtonText = isLastStep ? 'Submit' : 'Next';
     return (
@@ -245,6 +240,7 @@ export function SQFormDialogStepper<Values extends FormikValues>({
       onSubmit={handleSubmit}
       initialValues={initialValues}
       enableReinitialize={enableReinitialize}
+      validateOnMount={true}
     >
       {() => (
         <Dialog

--- a/stories/SQFormDialogStepper.stories.tsx
+++ b/stories/SQFormDialogStepper.stories.tsx
@@ -115,11 +115,16 @@ export const WithValidation = (
           label="Personal Data"
           validationSchema={Yup.object({
             firstName: Yup.string().required(),
-            lastName: Yup.string().required(),
+            middleName: Yup.string(),
+            lastName: Yup.string()
+              .required()
+              .min(3, 'Min 3 chars')
+              .max(25, 'Max 25 chars'),
           })}
         >
-          <SQFormTextField size={6} name="firstName" label="First Name" />
-          <SQFormTextField size={6} name="lastName" label="Last Name" />
+          <SQFormTextField size={4} name="firstName" label="First Name" />
+          <SQFormTextField size={4} name="middleName" label="Middle Name" />
+          <SQFormTextField size={4} name="lastName" label="Last Name" />
         </SQFormDialogStep>
         <SQFormDialogStep
           label="Account Info"

--- a/stories/__tests__/SQFormDialogStepper.stories.test.tsx
+++ b/stories/__tests__/SQFormDialogStepper.stories.test.tsx
@@ -145,7 +145,7 @@ describe('SQFormDialogStepper Tests', () => {
       const lastName = screen.getByLabelText(/last name/i);
       userEvent.type(lastName, 'Last');
 
-      expect(nextButton).toBeEnabled();
+      await waitFor(() => expect(nextButton).toBeEnabled());
     });
   });
 });


### PR DESCRIPTION
SQFormDialogStepper validation now respects validation schema properly.
SQFormDialogStepper now validations on mount.

BREAKING CHANGE: 🧨 SQFormDialogStepper respects validation schema

✅ Closes: #790

Loom: https://www.loom.com/share/6cd90ed9ec124121b0a72a187fbe0dc8

**DO NOT MERGE UNTIL #793 is merged**