### PR TITLE
feat: 🎸 throwAlertOnCancel control prop for SQFormDialog

### DIFF
--- a/src/components/SQFormDialog/SQFormDialog.tsx
+++ b/src/components/SQFormDialog/SQFormDialog.tsx
@@ -6,6 +6,7 @@ import type {FormikHelpers, FormikValues, FormikContextType} from 'formik';
 import type {DialogProps, GridProps, ButtonProps} from '@material-ui/core';
 import type {AnyObjectSchema} from 'yup';
 import type {SQFormDialogTertiaryValue} from './types';
+import {ThreeSixtyTwoTone} from '@material-ui/icons';
 
 export type SQFormDialogProps<Values extends FormikValues> = {
   /** The secondary button text (Button located on left side of Dialog) */
@@ -67,6 +68,8 @@ export type SQFormDialogProps<Values extends FormikValues> = {
   helperText?: string;
   /** helper text type to eventually get passed to SQFormHelperText component */
   helperTextType?: 'fail' | 'error' | 'valid';
+  /** option to throw an Are You Sure alert when hitting cancel while in the middle of filling out a the form.  true by default. */
+  throwAlertOnCancel?: boolean;
 };
 
 function SQFormDialog<Values extends FormikValues>({
@@ -93,6 +96,7 @@ function SQFormDialog<Values extends FormikValues>({
   tertiaryButtonVariant = 'outlined',
   helperText,
   helperTextType = 'error',
+  throwAlertOnCancel = true,
 }: SQFormDialogProps<Values>): React.ReactElement {
   const initialErrors = useInitialRequiredErrors(
     validationSchema,
@@ -128,6 +132,7 @@ function SQFormDialog<Values extends FormikValues>({
         tertiaryButtonVariant={tertiaryButtonVariant}
         helperText={helperText}
         helperTextType={helperTextType}
+        throwAlertOnCancel={throwAlertOnCancel}
       />
     </Formik>
   );

--- a/src/components/SQFormDialog/SQFormDialogInner.tsx
+++ b/src/components/SQFormDialog/SQFormDialogInner.tsx
@@ -67,6 +67,8 @@ type SQFormDialogInnerProps<Values extends FormikValues> = {
   helperText?: string;
   /** helper text type to pass to SQFormHelperText component */
   helperTextType?: 'fail' | 'error' | 'valid';
+  /** option to throw an Are You Sure alert when hitting cancel while in the middle of filling out a the form.  true by default. */
+  throwAlertOnCancel?: boolean;
 };
 
 /*
@@ -136,6 +138,7 @@ function SQFormDialogInner<Values extends FormikValues>({
   tertiaryButtonVariant,
   helperText,
   helperTextType = 'error',
+  throwAlertOnCancel = true,
 }: SQFormDialogInnerProps<Values>): React.ReactElement {
   const theme = useTheme();
   const titleClasses = useTitleStyles(theme);
@@ -169,7 +172,7 @@ function SQFormDialogInner<Values extends FormikValues>({
       return;
     }
 
-    if (!formikContext.dirty) {
+    if (!formikContext.dirty || !throwAlertOnCancel) {
       onClose && onClose(event, reason);
     } else {
       openDialogAlert();


### PR DESCRIPTION
throwAlertOnCancel allows the option to override the Are You Sure dialog when cancelling SQFormDialog while in the middle of filling out.  Set to true and will throw alert by default (same as previous behavior).

✅ Closes: SSR-189