### PR TITLE
SSR 149 validateOnBlur and validateOnChange options

### DIFF
--- a/src/components/SQForm/SQForm.tsx
+++ b/src/components/SQForm/SQForm.tsx
@@ -37,6 +37,10 @@ export type SQFormProps<Values extends FormikValues> = {
    * https://jaredpalmer.com/formik/docs/guides/validation#validationschema
    * */
   validationSchema?: AnyObjectSchema;
+  // Set if validation should happen on blur or not.  By default is set to true.
+  validateOnBlur?: boolean;
+  // Set if validation should happen on change.  By defautl is set to true.
+  validateOnChange?: boolean;
 };
 
 function SQForm<Values extends FormikValues>({
@@ -46,6 +50,8 @@ function SQForm<Values extends FormikValues>({
   muiGridProps = {},
   onSubmit,
   validationSchema,
+  validateOnBlur,
+  validateOnChange,
 }: SQFormProps<Values>): JSX.Element {
   const initialErrors = useInitialRequiredErrors(
     validationSchema,
@@ -76,6 +82,8 @@ function SQForm<Values extends FormikValues>({
       onReset={handleReset}
       validationSchema={validationSchema}
       validateOnMount={true}
+      validateOnBlur={validateOnBlur}
+      validateOnChange={validateOnChange}
     >
       {(_props) => {
         return (

--- a/src/components/SQForm/SQForm.tsx
+++ b/src/components/SQForm/SQForm.tsx
@@ -37,9 +37,9 @@ export type SQFormProps<Values extends FormikValues> = {
    * https://jaredpalmer.com/formik/docs/guides/validation#validationschema
    * */
   validationSchema?: AnyObjectSchema;
-  // Set if validation should happen on blur or not.  By default is set to true.
+  // Set if validation should happen on blur or not.  By default is set to true in Formik API.
   validateOnBlur?: boolean;
-  // Set if validation should happen on change.  By defautl is set to true.
+  // Set if validation should happen on change.  By default is set to true in Formik API.
   validateOnChange?: boolean;
 };
 

--- a/src/components/SQFormDialog/SQFormDialog.tsx
+++ b/src/components/SQFormDialog/SQFormDialog.tsx
@@ -69,6 +69,10 @@ export type SQFormDialogProps<Values extends FormikValues> = {
   helperTextType?: 'fail' | 'error' | 'valid';
   /** option to throw an Are You Sure alert when hitting cancel while in the middle of filling out a the form.  true by default. */
   throwAlertOnCancel?: boolean;
+  // Set if validation should happen on blur or not.  By default is set to true.
+  validateOnBlur?: boolean;
+  // Set if validation should happen on change.  By defautl is set to true.
+  validateOnChange?: boolean;
 };
 
 function SQFormDialog<Values extends FormikValues>({
@@ -96,6 +100,8 @@ function SQFormDialog<Values extends FormikValues>({
   helperText,
   helperTextType = 'error',
   throwAlertOnCancel = true,
+  validateOnBlur,
+  validateOnChange,
 }: SQFormDialogProps<Values>): React.ReactElement {
   const initialErrors = useInitialRequiredErrors(
     validationSchema,
@@ -110,6 +116,8 @@ function SQFormDialog<Values extends FormikValues>({
       onSubmit={onSave}
       validationSchema={validationSchema}
       validateOnMount={true}
+      validateOnBlur={validateOnBlur}
+      validateOnChange={validateOnChange}
     >
       <SQFormDialogInner<Values>
         cancelButtonText={cancelButtonText}

--- a/stories/SQForm.stories.tsx
+++ b/stories/SQForm.stories.tsx
@@ -27,6 +27,7 @@ import {
   SQFormMaskedTextField,
   SQFormMultiValue,
   MASKS,
+  SQFormDatePicker,
 } from '../src';
 import type {FieldArrayRenderProps, FormikHelpers} from 'formik';
 
@@ -304,6 +305,40 @@ export const FormWithValidation = (): JSX.Element => {
         >
           {MOCK_MULTI_VALUE_OPTIONS}
         </SQFormMultiValue>
+        <Grid item sm={12}>
+          <Grid container justifyContent="space-between">
+            <SQFormButton title="Reset" type="reset">
+              RESET
+            </SQFormButton>
+            <FormValidationMessage />
+
+            <SQFormButton>Submit</SQFormButton>
+          </Grid>
+        </Grid>
+      </SQForm>
+    </Card>
+  );
+};
+
+export const FormWithOnBlurValidation = (): JSX.Element => {
+  const validationSchema = Yup.object({
+    datePicker: Yup.date()
+      .required()
+      .min(new Date('2020-09-22'), 'Date must be after 09/22/20')
+      .max(new Date('2100-10-10'), 'Date must be after 10/10/2100')
+      .typeError('Invalid date'),
+  });
+
+  return (
+    <Card raised style={{padding: 16}}>
+      <SQForm
+        initialValues={{datePicker: new Date()}}
+        onSubmit={handleSubmit}
+        validationSchema={validationSchema}
+        validateOnBlur={true}
+        validateOnChange={false}
+      >
+        <SQFormDatePicker name="datePicker" label="DatePicker" />
         <Grid item sm={12}>
           <Grid container justifyContent="space-between">
             <SQFormButton title="Reset" type="reset">

--- a/stories/SQFormDialog.stories.tsx
+++ b/stories/SQFormDialog.stories.tsx
@@ -17,9 +17,9 @@ type DefaultArgsValues = {hello: string};
 type SQFormDialogStory = Story<SQFormDialogProps<DefaultArgsValues>>;
 
 type WithDatePickersValues = {
-  datePicker: string;
-  dateTimePicker: string;
-  datePickerCalendarOnly: string;
+  datePicker: Date;
+  dateTimePicker: Date;
+  datePickerCalendarOnly: Date;
 };
 type SQFormDialogWithDatePickersStory = Story<
   SQFormDialogProps<WithDatePickersValues>
@@ -125,10 +125,77 @@ WithDatePickers.args = {
   ...defaultArgs,
   title: 'With Date Pickers',
   initialValues: {
-    datePicker: '',
-    dateTimePicker: '',
-    datePickerCalendarOnly: '',
+    datePicker: new Date(),
+    dateTimePicker: new Date(),
+    datePickerCalendarOnly: new Date(),
   },
+  validationSchema: Yup.object({
+    datePicker: Yup.date()
+      .required()
+      .min(new Date('2020-09-22'), 'Date must be after 09/22/20')
+      .max(new Date('2100-10-10'), 'Date must be after 10/10/2100')
+      .typeError('Invalid date'),
+    dateTimePicker: Yup.date()
+      .required()
+      .min(new Date('2020-09-22'), 'Date must be after 09/22/20')
+      .max(new Date('2100-10-10'), 'Date must be after 10/10/2100')
+      .typeError('Invalid date'),
+    datePickerCalendarOnly: Yup.date()
+      .required()
+      .min(new Date('2020-09-22'), 'Date must be after 09/22/20')
+      .max(new Date('2100-10-10'), 'Date must be after 10/10/2100')
+      .typeError('Invalid date'),
+  }),
+};
+
+export const WithOnBlurValidation: SQFormDialogWithDatePickersStory = (
+  args
+) => {
+  return (
+    <>
+      <h1>
+        Toggle the Dialog's <code>isOpen</code> state in the Controls tab
+      </h1>
+
+      <SQFormDialog {...args}>
+        <SQFormDatePicker name="datePicker" label="DatePicker" />
+        <SQFormDateTimePicker name="dateTimePicker" label="DateTimePicker" />
+        <SQFormDatePickerWithCalendarInputOnly
+          name="datePickerCalendarOnly"
+          label="DatePickerWithCalendarInputOnly"
+        />
+      </SQFormDialog>
+    </>
+  );
+};
+
+WithOnBlurValidation.args = {
+  ...defaultArgs,
+  title: 'With Date Pickers',
+  initialValues: {
+    datePicker: new Date(),
+    dateTimePicker: new Date(),
+    datePickerCalendarOnly: new Date(),
+  },
+  validationSchema: Yup.object({
+    datePicker: Yup.date()
+      .required()
+      .min(new Date('2020-09-22'), 'Date must be after 09/22/20')
+      .max(new Date('2100-10-10'), 'Date must be after 10/10/2100')
+      .typeError('Invalid date'),
+    dateTimePicker: Yup.date()
+      .required()
+      .min(new Date('2020-09-22'), 'Date must be after 09/22/20')
+      .max(new Date('2100-10-10'), 'Date must be after 10/10/2100')
+      .typeError('Invalid date'),
+    datePickerCalendarOnly: Yup.date()
+      .required()
+      .min(new Date('2020-09-22'), 'Date must be after 09/22/20')
+      .max(new Date('2100-10-10'), 'Date must be after 10/10/2100')
+      .typeError('Invalid date'),
+  }),
+  validateOnBlur: true,
+  validateOnChange: false,
 };
 
 export const WithTertiaryButton: SQFormDialogStory = (args) => {


### PR DESCRIPTION
This adds the feature to be able to control if we are validating onChange or onBlur for both the SQForm and SQFormDialog components.  By default both are set to true (as they have behaved previously), and each can be deactivated by setting to false.

closes issue [#808 ](https://github.com/SelectQuoteLabs/SQForm/issues/808)

Ticket [SSR-149](https://selectquote.atlassian.net/browse/SSR-149?atlOrigin=eyJpIjoiNTc4MDcwYjk1OTBjNGQ1ZDk2YzdlMWJlNzY4YTc4ZTEiLCJwIjoiaiJ9)

[Loom video demoing new feature and stories](https://www.loom.com/share/2d032be41aee4e0f9f5afebde7bb0224)