### PR TITLE
Dialog, DialogAlert, and DialogForm shared component updates

### DIFF
--- a/src/components/SQFormDialog/SQFormDialogInner.tsx
+++ b/src/components/SQFormDialog/SQFormDialogInner.tsx
@@ -99,7 +99,7 @@ const actionStyles = (theme: Theme) => ({
   flex: '1 1 100%',
   ...stickyStyles(theme),
   bottom: 0,
-  borderTop: `1px solid B3B3B3`,
+  borderTop: `1px solid #B3B3B3`,
   padding: '8px 16px',
   height: '47px',
 });
@@ -109,7 +109,7 @@ const useClasses = (theme: Theme) => ({
   title: {
     ...stickyStyles(theme),
     top: 0,
-    borderBottom: `1px solid B3B3B3`,
+    borderBottom: `1px solid #B3B3B3`,
     padding: '12px 16px',
     height: '48px',
   },

--- a/src/components/SQFormDialog/SQFormDialogInner.tsx
+++ b/src/components/SQFormDialog/SQFormDialogInner.tsx
@@ -111,7 +111,7 @@ const useClasses = (theme: Theme) => ({
     top: 0,
     borderBottom: `1px solid #B3B3B3`,
     padding: '12px 16px',
-    height: '48px',
+    height: '49px',
   },
   action: actionStyles(theme),
   primaryAction: {

--- a/src/components/SQFormDialog/SQFormDialogInner.tsx
+++ b/src/components/SQFormDialog/SQFormDialogInner.tsx
@@ -278,7 +278,7 @@ function SQFormDialogInner<Values extends FormikValues>({
             // See: https://github.com/mui/material-ui/issues/27851#issuecomment-998996294
             // Known problem in MUI v5, as of @mui/material@5.9.2
             style={{
-              paddingTop: '20px',
+              paddingTop: '24px',
             }}
             sx={classes.dialogContent}
           >

--- a/src/components/SQFormDialog/SQFormDialogInner.tsx
+++ b/src/components/SQFormDialog/SQFormDialogInner.tsx
@@ -97,10 +97,11 @@ const actionStyles = (theme: Theme) => ({
   display: 'flex',
   justifyContent: 'space-between',
   flex: '1 1 100%',
-  padding: '10px 20px',
   ...stickyStyles(theme),
   bottom: 0,
-  borderTop: `1px solid ${theme.palette.divider}`,
+  borderTop: `1px solid B3B3B3`,
+  padding: '8px 16px',
+  height: '47px',
 });
 
 const useClasses = (theme: Theme) => ({
@@ -108,7 +109,9 @@ const useClasses = (theme: Theme) => ({
   title: {
     ...stickyStyles(theme),
     top: 0,
-    borderBottom: `1px solid ${theme.palette.divider}`,
+    borderBottom: `1px solid B3B3B3`,
+    padding: '12px 16px',
+    height: '48px',
   },
   action: actionStyles(theme),
   primaryAction: {
@@ -117,7 +120,7 @@ const useClasses = (theme: Theme) => ({
   },
   dialogContent: {
     overflowY: 'visible',
-    padding: '20px',
+    padding: '16px 16px 32px 16px',
   },
 });
 
@@ -268,7 +271,7 @@ function SQFormDialogInner<Values extends FormikValues>({
       >
         <Form>
           <DialogTitle sx={classes.title}>
-            <Typography variant="h4">{title}</Typography>
+            <Typography variant="h5">{title}</Typography>
           </DialogTitle>
           <DialogContent
             // DialongContent paddingTop is overwritten by some title styling. Applying directly


### PR DESCRIPTION
Description

Link for Inspect: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=1518%3A13147) 

Update the SQformDialog component with the following specs:

SQFormDialog 

Header: 
Text: H5 (24pt; Regular/400)
Padding above/below text: 12px
Padding left/right text: 16px
Divider: 1px, B3B3B3
Total header height = 48px

Body:
Set padding around container to 16px top, left, right; 32px bottom

Footer
Divider: 1px, B3B3B3
Padding above/below buttons: 8px
Padding left/right buttons: 16px
Button color: Should be updated to [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=1518%3A10320) 
Total footer height = 47

Adjusted padding, divider color and header varient of the mentioned SQFormDialog sections

✅ Closes: #817

![Screenshot 2022-12-02 at 4 14 04 PM](https://user-images.githubusercontent.com/55225884/205400894-ddc0d12a-0978-4d8f-8d58-7c88d19d3733.png)
