### PR TITLE
Ssr 169/update scrollable card styles

### DIFF
--- a/src/components/SQForm/SQFormHelperText.tsx
+++ b/src/components/SQForm/SQFormHelperText.tsx
@@ -90,11 +90,13 @@ function SQFormHelperText({
         sx={(theme) => {
           return {
             mr: theme.spacing(1),
-            fontSize: '24px',
+            fontSize: '22px',
           };
         }}
       />
-      <Typography variant="h6">{helperTextMap[helperTextType]}</Typography>
+      <Typography variant="subtitle2">
+        {helperTextMap[helperTextType]}
+      </Typography>
     </Grid>
   );
 }

--- a/src/components/SQFormScrollableCard/SQFormScrollableCard.tsx
+++ b/src/components/SQFormScrollableCard/SQFormScrollableCard.tsx
@@ -5,7 +5,6 @@ import {useDebouncedCallback} from 'use-debounce';
 import SQFormButton from '../SQForm/SQFormButton';
 import SQFormHelperText from '../SQForm/SQFormHelperText';
 import {useInitialRequiredErrors} from '../../hooks/useInitialRequiredErrors';
-import {HEADER_HEIGHT} from '../../utils/constants';
 import type {GridProps} from '@mui/material';
 import type {FormikHelpers, FormikValues} from 'formik';
 import type {AnyObjectSchema} from 'yup';
@@ -189,8 +188,8 @@ function SQFormScrollableCard<Values extends FormikValues>({
                     sx={(theme) => ({
                       gridArea: 'header',
                       borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
-                      padding: `${theme.spacing(2)} ${theme.spacing(3)}`,
-                      height: HEADER_HEIGHT, // overrides a scplus-shared-component theme hard coded height
+                      padding: `${theme.spacing(1.5)} ${theme.spacing(3)}`,
+                      height: '49px', // overrides a scplus-shared-component theme hard coded height
                     })}
                     titleTypographyProps={{variant: 'h5'}}
                     avatar={icon}
@@ -201,7 +200,9 @@ function SQFormScrollableCard<Values extends FormikValues>({
                   sx={(theme) => ({
                     gridArea: 'content',
                     overflowY: 'auto',
-                    p: `${theme.spacing(2)}`,
+                    p: `${theme.spacing(3)} ${theme.spacing(2)} ${theme.spacing(
+                      4
+                    )} ${theme.spacing(2)}`,
                     ...cardContentStyles,
                     '& .MuiGrid-root.MuiGrid-item': {
                       p: theme.spacing(1),
@@ -225,6 +226,7 @@ function SQFormScrollableCard<Values extends FormikValues>({
                 </CardContent>
                 <CardActions
                   sx={(theme) => ({
+                    height: '47px',
                     gridArea: 'footer',
                     display: 'flex',
                     justifyContent: 'space-between',


### PR DESCRIPTION
Description
As a developer, I need to update the SQForm components, so that they match design library patterns.

Updates needed on SQFormScrollableCard:
Follow specifications per component design: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=1518%3A13147) 

Changes needed:

- Header = 49px height
1. (Text style H5 of 24pt weight 400 + 12px padding above below header + 1px divider line)

- Footer =,47px height
1. (Button height = 30px + 8px padding above below header + 1px divider line)
2. Padding around content should be 24px top, 16px left and right, and 32px bottom

- SQFormHelperText component
1. Update helperText to text style Subtitle2 (14pt, weight 600). Reference: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=1231%3A12596) 
2. Confirm helperText icon container is 20x20 px.  Reference: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=1231%3A12596)

<img width="1029" alt="Screenshot 2022-12-08 at 2 28 09 PM" src="https://user-images.githubusercontent.com/55225884/206561725-a6dc649e-7a99-4b0c-a52c-22956bdcf731.png">

Updates also affect SQFormDialog styles where the SQFormHelperText component is used as well:
<img width="1029" alt="Screenshot 2022-12-08 at 2 35 25 PM" src="https://user-images.githubusercontent.com/55225884/206562116-491426f5-172b-4116-b33c-e0be6fe13a8c.png">
