### PR TITLE
fix: 🐛 SQFormScrollableCard submit mock fix

### DIFF
--- a/stories/__tests__/SQFormScrollableCard.stories.test.tsx
+++ b/stories/__tests__/SQFormScrollableCard.stories.test.tsx
@@ -13,7 +13,6 @@ const {
   WithIcon,
   WithStaticHeight,
 } = composeStories(stories);
-const handleSubmit = jest.fn();
 
 describe('SQFormScrollableCard', () => {
   // test isDisabled, onSubmit, submitButtonText, resetButtonText and reset button
@@ -28,6 +27,7 @@ describe('SQFormScrollableCard', () => {
     });
 
     it('Should call submit handler on click', async () => {
+      const handleSubmit = jest.fn();
       render(<Default onSubmit={handleSubmit} />);
 
       userEvent.type(screen.getByLabelText(/hello/i), 'TypingFifteenChars');


### PR DESCRIPTION
Attempting to fix failing CI pipeline tests by moving scope of SQFormScrollableCard submit mock to inside the scope of the test it is working with.

✅ Closes: #826

<img width="879" alt="Screenshot 2023-01-17 at 2 08 54 PM" src="https://user-images.githubusercontent.com/55225884/213007562-0592c624-826b-4996-9d1b-11dd13341f4a.png">

[1_ci (1).txt](https://github.com/SelectQuoteLabs/SQForm/files/10439215/1_ci.1.txt)
