### PR TITLE
style: 💄 update SQFormAutocomplete styles

### DIFF
--- a/src/components/SQForm/SQFormAutocomplete.tsx
+++ b/src/components/SQForm/SQFormAutocomplete.tsx
@@ -319,6 +319,22 @@ function SQFormAutocomplete({
           // This makes sure the autocomplete options list width is never less than the input field width
           minWidth: `${Number(baseWidth ?? 0) + LISTBOX_PADDING}px !important`,
         },
+        '& .MuiInputBase-root.Mui-error:before': {
+          borderColor: 'var(--color-textWarningYellow)',
+        },
+        '& .Mui-error': {
+          color: 'var(--color-textWarningYellow)',
+        },
+        '& .MuiFormHelperText-root > .MuiSvgIcon-colorError': {
+          color: 'var(--color-textWarningYellow)',
+        },
+        '& .MuiFormHelperText-root > .MuiSvgIcon-root:not(.MuiSvgIcon-colorDisabled):not(.MuiSvgIcon-colorError)':
+          {
+            color: 'var(--color-textSuccessGreen)',
+          },
+        '& .MuiInputBase-root.Mui-error': {
+          borderColor: 'var(--color-textWarningYellow)',
+        },
       }}
     >
       <Autocomplete
@@ -387,7 +403,7 @@ function SQFormAutocomplete({
         }}
         renderOption={(props, option) => (
           <li {...props}>
-            <Typography variant="body2" noWrap={true}>
+            <Typography variant="body2" sx={{fontWeight: 600}} noWrap={true}>
               {option.label}
             </Typography>
           </li>


### PR DESCRIPTION
Updated sizing and weight for label and value text. Switched success and warning colors in validation to new 'textWarningGYellow' and 'textSuccessGreen' styles.

Update the current implementation of the Autocomplete with added specifications. Here is the current implementation of this SQForm: [Webpack App](https://master--5f4431386ea00a00220d495c.chromatic.com/?path=/story/components-sqformautocomplete--default) (this is an example link)

Design reference: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=1518%3A11678)
Typography: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=340%3A9946)
Color: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=340%3A9646)

Default:
Label: Text Style: Label 12 px Weight: 400
Value: Text Style: Value 14px Weight: 600 Semi-bold

Focused:
Label: Text Style: Label 12 px Weight: 400
Value: Text Style: Value 14px Weight: 600 Semi-bold

With Validation:
Label: Text Style: Label 12 px Weight: 400
Value: Text Style: Value 14px Weight: 600 Semi-bold
Line: #C67000 Warning
Helper Text/icon: #C67000 Warning #3C7107 Text/Success
Icon Size: 12 x 11 Warning 9 x 11 Success badge

✅ Closes: #836

Loom Demo: [here](https://www.loom.com/share/c5c74522ce0a405db62ec1d2beecf679)