### PR TITLE
fix: 🐛 HelperText console error

### DIFF
--- a/src/components/SQForm/useForm.tsx
+++ b/src/components/SQForm/useForm.tsx
@@ -141,7 +141,10 @@ export function useForm<TValue, TChangeEvent>({
       return (
         <>
           <WarningIcon color="error" sx={WARNING_ICON_STYLES} />
-          <Typography sx={(theme: Theme) => theme.typography.helper}>
+          <Typography
+            component="span"
+            sx={(theme: Theme) => theme.typography.helper}
+          >
             {errorMessage}
           </Typography>
         </>
@@ -151,7 +154,10 @@ export function useForm<TValue, TChangeEvent>({
       return (
         <>
           <WarningIcon color="disabled" sx={WARNING_ICON_STYLES} />
-          <Typography sx={(theme: Theme) => theme.typography.helper}>
+          <Typography
+            component="span"
+            sx={(theme: Theme) => theme.typography.helper}
+          >
             Required
           </Typography>
         </>


### PR DESCRIPTION
Fixes the `<p> cannot appear as a descendant of <p>` console error that appears in dev console and during tests.

✅ Closes: #838
<img width="1091" alt="Screen Shot 2023-02-20 at 11 21 50 AM" src="https://user-images.githubusercontent.com/29528409/220169006-aedb3727-fbf4-412c-96e1-f9b421a5a341.png">

