### PR TITLE
SSR-163: SQForms: Masked Read Only Field - Update component

### DIFF
--- a/src/components/fields/SQFormMasked/SQFormMaskedReadOnlyField.tsx
+++ b/src/components/fields/SQFormMasked/SQFormMaskedReadOnlyField.tsx
@@ -54,6 +54,9 @@ function SQFormMaskedReadOnlyField({
         ...InputProps,
         placeholder,
         inputComponent: TextFieldMask,
+        sx: {
+          fontWeight: 600,
+        },
       }}
       inputProps={{
         ...inputProps,


### PR DESCRIPTION
Update the current implementation of the Masked Read Only Field with added specifications. Here is the current implementation of this SQForm: https://master--5f4431386ea00a00220d495c.chromatic.com/?path=/story/components-sqformmaskedreadonlyfield--default  (this is an example link)



Design reference: https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=1518%3A11678 
Typography: https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=340%3A9946 
Color: https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=340%3A9646 

Default:

Label:  Text Style: Label 12 px Weight: 400
Value: Text Style: Value 14px Weight: 600 Semi-bold

Loom Demo: [here](https://www.loom.com/share/309a383180244435b6b4e3e2327c9f2el)