### PR TITLE
feat: 🎸 Update SQForm Masked TextField

### DIFF
--- a/src/components/fields/SQFormMasked/SQFormMaskedTextField.tsx
+++ b/src/components/fields/SQFormMasked/SQFormMaskedTextField.tsx
@@ -82,7 +82,14 @@ function SQFormMaskedTextField({
         ...inputProps,
         mask,
       }}
-      muiFieldProps={muiFieldProps}
+      muiFieldProps={{
+        sx: {
+          '& .MuiInput-input': {
+            fontWeight: 'var(--font-weight-semibold)',
+          },
+        },
+        ...muiFieldProps,
+      }}
     />
   );
 }

--- a/src/components/fields/SQFormMasked/SQFormMaskedTextField.tsx
+++ b/src/components/fields/SQFormMasked/SQFormMaskedTextField.tsx
@@ -77,19 +77,15 @@ function SQFormMaskedTextField({
       InputProps={{
         ...InputProps,
         inputComponent: TextFieldMask,
+        sx: {
+          fontWeight: 'var(--font-weight-semibold)',
+        },
       }}
       inputProps={{
         ...inputProps,
         mask,
       }}
-      muiFieldProps={{
-        sx: {
-          '& .MuiInput-input': {
-            fontWeight: 'var(--font-weight-semibold)',
-          },
-        },
-        ...muiFieldProps,
-      }}
+      muiFieldProps={muiFieldProps}
     />
   );
 }


### PR DESCRIPTION
Update the current implementation of the Masked Text Field with added specifications. Here is the current implementation of this SQForm: [Webpack App](https://master--5f4431386ea00a00220d495c.chromatic.com/?path=/story/components-sqformmaskedtextfield--default)  (this is an example link)

Design reference: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=1518%3A11678) 
Typography: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=340%3A9946) 
Color: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=340%3A9646) 

Default:
Label:  Text Style: Label 12 px Weight: 400
Value: Text Style: Value 14px Weight: 600 Semi-bold

Screenshot
![Screenshot 2023-03-13 230026](https://user-images.githubusercontent.com/126600957/224802631-55d53f18-650a-47c9-91fd-d0cd74d1ee48.png)
