### PR TITLE
874 sqforms readonlyfield update component

### DIFF
--- a/src/components/fields/SQFormReadOnlyField/SQFormReadOnlyField.tsx
+++ b/src/components/fields/SQFormReadOnlyField/SQFormReadOnlyField.tsx
@@ -11,11 +11,12 @@ export type SQFormReadOnlyFieldProps = BaseFieldProps & {
   inputProps?: TextFieldProps['inputProps'];
 };
 
+const readOnlyInputProps = {
+  disableUnderline: true,
+  readOnly: true,
+};
+
 const styles = {
-  '& .MuiInput-root:before, & .MuiInput-root:after, & .MuiInput-underline:hover:not(.Mui-disabled):not(.Mui-multiline):before':
-    {
-      borderBottom: '0px',
-    },
   '& .MuiInput-input': {
     fontWeight: 'var(--font-weight-semibold)',
   },
@@ -51,12 +52,12 @@ function SQFormReadOnlyField({
         InputLabelProps={{shrink: true}}
         InputProps={{
           ...InputProps,
-          readOnly: true,
+          ...readOnlyInputProps,
         }}
         inputProps={inputProps}
         style={{marginBottom: 21}}
-        {...muiFieldProps}
         sx={styles}
+        {...muiFieldProps}
       />
     </Grid>
   );

--- a/src/components/fields/SQFormReadOnlyField/SQFormReadOnlyField.tsx
+++ b/src/components/fields/SQFormReadOnlyField/SQFormReadOnlyField.tsx
@@ -12,7 +12,7 @@ export type SQFormReadOnlyFieldProps = BaseFieldProps & {
 };
 
 const styles = {
-  '& .MuiInput-root:before, & .MuiInput-root:after, & .MuiInput-underline:hover:not(.Mui-disabled):before':
+  '& .MuiInput-root:before, & .MuiInput-root:after, & .MuiInput-underline:hover:not(.Mui-disabled):not(.Mui-multiline):before':
     {
       borderBottom: '0px',
     },

--- a/src/components/fields/SQFormReadOnlyField/SQFormReadOnlyField.tsx
+++ b/src/components/fields/SQFormReadOnlyField/SQFormReadOnlyField.tsx
@@ -11,6 +11,16 @@ export type SQFormReadOnlyFieldProps = BaseFieldProps & {
   inputProps?: TextFieldProps['inputProps'];
 };
 
+const styles = {
+  '& .MuiInput-root:before, & .MuiInput-root:after, & .MuiInput-underline:hover:not(.Mui-disabled):before':
+    {
+      borderBottom: '0px',
+    },
+  '& .MuiInput-input': {
+    fontWeight: 'var(--font-weight-semibold)',
+  },
+};
+
 function SQFormReadOnlyField({
   label,
   name,
@@ -46,6 +56,7 @@ function SQFormReadOnlyField({
         inputProps={inputProps}
         style={{marginBottom: 21}}
         {...muiFieldProps}
+        sx={styles}
       />
     </Grid>
   );


### PR DESCRIPTION
Update the current implementation of the ReadOnlyField with added specifications. Here is the current implementation of this SQForm: [Webpack App](https://master--5f4431386ea00a00220d495c.chromatic.com/?path=/story/components-sqformreadonlyfield--default)    (this is an example link)

Design reference: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=1518%3A11678) 
Typography: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=340%3A9946) 
Color: [SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-SYSTEM?node-id=340%3A9646) 

Default:
Label:  Text Style: Label 12 px Weight: 400
Value: Text Style: Value 14px Weight: 600 Semi-bold

Note: Underline in the read-only needs to be removed

Loom Link: [Loom](https://www.loom.com/share/1aa834f6e013457393ec0a24c623feb0)

closes: #874 








