### PR TITLE
test: 💍 Update DatePicker tests

### DIFF
--- a/stories/__tests__/SQFormDatePicker.stories.test.tsx
+++ b/stories/__tests__/SQFormDatePicker.stories.test.tsx
@@ -20,7 +20,7 @@ const renderDatePicker = (
   >
 ) => {
   return render(
-    <LocalizationProvider dateAdapter={AdapterMoment} locale={'en'}>
+    <LocalizationProvider dateAdapter={AdapterMoment} adapterLocale={'en'}>
       <BasicDatePicker {...props} />
     </LocalizationProvider>
   );
@@ -72,9 +72,8 @@ describe('SQFormDatePicker Tests', () => {
     const datePickerButton = screen.getByRole('button', {name: /choose date/i});
 
     userEvent.click(datePickerButton);
-    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
 
-    await screen.findByRole('dialog');
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
 
     const calendarDialog = screen.getByRole('dialog');
     expect(calendarDialog).toBeInTheDocument();
@@ -92,7 +91,7 @@ describe('SQFormDatePicker Tests', () => {
     const datePickerButton = screen.getByRole('button', {name: /Choose date/i});
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     userEvent.click(datePickerButton);
-    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
     const calendarDialog = screen.getByRole('dialog');
     expect(calendarDialog).toBeInTheDocument();
     expect(calendarDialog).toBeVisible();
@@ -144,10 +143,8 @@ describe('SQFormDatePicker Tests', () => {
     };
 
     const {container} = renderDatePicker({sqFormProps});
-    await waitFor(() => {
-      const helperText = container.querySelector('.MuiFormHelperText-root');
-      expect(helperText).toBeVisible();
-      expect(helperText).toHaveClass('Mui-required');
-    });
+    const helperText = container.querySelector('.MuiFormHelperText-root');
+    await waitFor(() => expect(helperText).toBeVisible());
+    await waitFor(() => expect(helperText).toHaveClass('Mui-required'));
   });
 });


### PR DESCRIPTION
Changes in this PR are mainly due to VSCode react-testing-library intellisense suggestions.  There is still an ongoing "issue" with the datepicker tests where the input and calendar button seem to be treated as one input with the role of `textbox`.  Due to the fact that this seems to be controlled by MUI, it may not be doable to alter this on our end.  See discussion on the issue if interested https://github.com/SelectQuoteLabs/SQForm/issues/876.

<img width="682" alt="Screen Shot 2023-04-12 at 10 50 19 AM" src="https://user-images.githubusercontent.com/16596855/231519535-c51afca3-c91e-421b-a931-eff8776e19f9.png">

✅ Closes: #876