### PR TITLE
feat: 🎸 Add prop for SQForm questions to support rich text

### DIFF
--- a/src/components/fields/SQFormDropdown/SQFormDropdown.tsx
+++ b/src/components/fields/SQFormDropdown/SQFormDropdown.tsx
@@ -7,6 +7,7 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  Typography,
 } from '@mui/material';
 import {useForm} from '../../../hooks/useForm';
 import {
@@ -33,6 +34,8 @@ export type SQFormDropdownProps = BaseFieldProps & {
   onChange?: SelectProps['onChange'];
   /** Any valid prop for material ui select child component - https://material-ui.com/api/select/#props  */
   muiFieldProps?: SelectProps;
+  /** OPTIONAL - Questions that could be asked with the dropdown label */
+  questions?: string[];
 };
 
 const EMPTY_VALUE = '';
@@ -48,6 +51,15 @@ const classes = {
       height: '1.1876em',
     },
   },
+  typograpyStyle: {
+    color: 'var(--color-granite)',
+    fontSize: 'var(--base-font-size)',
+    fontWeight: 'var(--font-weight-normal)',
+    whiteSpace: 'pre-line',
+    marginLeft: '25px',
+    marginTop: '20px',
+    lineHeight: '15px',
+  },
 };
 
 function SQFormDropdown({
@@ -61,6 +73,7 @@ function SQFormDropdown({
   onChange,
   size = 'auto',
   muiFieldProps = {},
+  questions,
 }: SQFormDropdownProps): React.ReactElement {
   const {
     formikField: {field},
@@ -136,6 +149,11 @@ function SQFormDropdown({
         <InputLabel shrink={true} id={labelID}>
           {label}
         </InputLabel>
+        {questions && (
+          <Typography sx={classes.typograpyStyle}>
+            {questions.map((question) => `- ${question}\n`)}
+          </Typography>
+        )}
         <Select
           sx={classes.selectHeight}
           displayEmpty={true}

--- a/stories/SQFormDropdown.stories.tsx
+++ b/stories/SQFormDropdown.stories.tsx
@@ -21,6 +21,12 @@ type DropdownStoryType = Story<
   }
 >;
 
+const questions = [
+  'What benefits do you use most often?',
+  "Are there benefits that you don't use today, but would like to learn if you have them?",
+  'Are there any questions that you have about your plan?',
+];
+
 const meta: Meta = {
   title: 'Components/SQFormDropdown',
   component: SQFormDropdownComponent,
@@ -48,7 +54,7 @@ const MOCK_STATE_OPTIONS = [
 ];
 
 const defaultArgs = {
-  label: 'State',
+  label: 'Is there anything else you would like your plan to do for you?',
   name: 'state',
   children: MOCK_STATE_OPTIONS,
   sqFormProps: {
@@ -65,7 +71,11 @@ const Template: DropdownStoryType = (args) => {
         validationSchema={schema}
         {...sqFormProps}
       >
-        <SQFormDropdownComponent {...dropdownProps} size={getSizeProp(size)} />
+        <SQFormDropdownComponent
+          {...dropdownProps}
+          size={getSizeProp(size)}
+          questions={questions}
+        />
       </SQFormStoryWrapper>
     </div>
   );


### PR DESCRIPTION
Added support for bulleted list for dropdown questions that were converting to plain text before

Currently SQForm does not support bulleted lists, rather converts questions to plain text.
We need the ability to structure form fields in a way that will allow designers to meet business requirements.
Use case:

We are unable to implement requirements due to SQFormDropdown limitations that would not allow indenting or using bullets in a single form question:

![image-20220126-191814](https://user-images.githubusercontent.com/126600957/235744633-4f53298a-db1d-438e-acf4-1e42438f5365.png)


The result is that SQ from converted this into multi-line structure with no ability to format:

![image-20220126-191950](https://user-images.githubusercontent.com/126600957/235744696-e14c0f7d-e614-43ff-b15b-5e2252c88396.png)


Figma Design file:

[SC3 DESIGN LIBRARY](https://www.figma.com/file/DsJr2cFZqMYkOX6VjcuhqW/SC3-DESIGN-LIBRARY?node-id=340%3A9947&t=rbmYFWugsQlSQ6qH-0)

BREAKING CHANGE: 🧨 No

✅ Closes: #885