### PR TITLE
Adjust Github actions for maintenance releases

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,10 @@
 name: Node CI
 
 on:
+  push:
+    branches:
+      - master
+      - '*maintenance-release*'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - '*maintenance-release*'
 
 jobs:
   publish:

--- a/.github/workflows/Storybook.yml
+++ b/.github/workflows/Storybook.yml
@@ -2,7 +2,8 @@ name: Deploy Storybook
 
 on:
   push:
-    branches: [master]
+    branches: 
+      - master
 
 jobs:
   storybook:

--- a/release.config.js
+++ b/release.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   repositoryUrl: 'https://github.com/SelectQuoteLabs/SQForm.git',
   // Semantic release will only release off the master branch and any branch with a name like 9.x or 7.7.x, etc
-  branches: ['+([0-9])?(.{+([0-9]),x}).x', 'master'],
+  branches: ['*maintenance-release*', 'master'],
   plugins: [
     '@semantic-release/commit-analyzer',
     [


### PR DESCRIPTION
Modified github actions to allow for maintenance releases. Will only trigger on the master branch and branches that contain the string `maintenance-release`