### PR TITLE
SC3-1811 transfer step

### DIFF
--- a/src/components/SQFormTransferTool/AccordionBody.tsx
+++ b/src/components/SQFormTransferTool/AccordionBody.tsx
@@ -6,27 +6,81 @@ import {
   TextButton,
 } from 'scplus-shared-components';
 import Step from './Step';
-import type {OnTransfer, TransferProduct} from './types';
+import {useSQFormContext} from '../../../src';
+import {getIsConditionMet} from './util';
+import type {
+  OnTransfer,
+  TransferProduct,
+  FormValues,
+  CallBackData,
+} from './types';
 
 export type AccordionBodyProps = {
   transferProduct: TransferProduct;
   onTransfer: OnTransfer;
 };
 
+/**
+ * Transforms the form values into a more friendly format. Specifically the
+ * same form that the step condition uses to define questions and answers
+ * with the exception that the value can be null, representing an empty value
+ */
+function transformValues(values: FormValues): CallBackData['questionAnswers'] {
+  return Object.entries(values).map(([key, value]) => {
+    return {
+      questionId: Number(key),
+      answerId: value === '' ? null : Number(value),
+    };
+  });
+}
+
+function getIsTransferConditionMet(
+  transferProduct: TransferProduct,
+  values: FormValues
+) {
+  // There can be only one transferStep in a Transfer Product
+  const transferStep = transferProduct.steps.find(
+    ({type}) => type === 'transfer'
+  );
+
+  if (transferStep?.condition === undefined) {
+    console.warn('Malformed data, missing transfer step');
+    return false;
+  }
+
+  return getIsConditionMet(transferStep.condition, values);
+}
+
 export default function AccordionBody({
   transferProduct,
   onTransfer,
 }: AccordionBodyProps): React.ReactElement {
   const {productDisplayName, modalLinkText} = transferProduct;
+  const {values} = useSQFormContext<FormValues>();
 
   function handleTransfer() {
-    onTransfer('TODO this needs implemented');
+    const questionAnswers = transformValues(values);
+    const {productID, transferLine} = transferProduct;
+    // TODO we will also include a log of open panels
+
+    onTransfer({transferLine, questionAnswers, productID});
   }
+
+  const isTransferConditionMet = getIsTransferConditionMet(
+    transferProduct,
+    values
+  );
+
+  const tooltip = isTransferConditionMet ? modalLinkText : 'Condition Not Met';
 
   return (
     <Section sx={{marginBottom: '0px'}}>
       <SectionHeader title={productDisplayName}>
-        <TextButton onClick={handleTransfer} tooltip={modalLinkText}>
+        <TextButton
+          onClick={handleTransfer}
+          tooltip={tooltip}
+          isDisabled={!isTransferConditionMet}
+        >
           {modalLinkText}
         </TextButton>
       </SectionHeader>

--- a/src/components/SQFormTransferTool/SQFormTransferProductPanels.tsx
+++ b/src/components/SQFormTransferTool/SQFormTransferProductPanels.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {Box} from '@mui/material';
 import {Accordion} from 'scplus-shared-components';
-import type {AccordionPanelType} from 'scplus-shared-components';
 import AccordionBody from './AccordionBody';
+import type {AccordionPanelType} from 'scplus-shared-components';
 import type {TransferProduct, OnTransfer} from './types';
 
 export type SQFormTransferProductPanelsProps = {
@@ -20,6 +20,7 @@ function getPanels(
 
   return transferProducts.map((transferProduct) => {
     const {productID, productDisplayName, enabled} = transferProduct;
+
     return {
       body: (
         <AccordionBody

--- a/src/components/SQFormTransferTool/SQFormTransferTool.tsx
+++ b/src/components/SQFormTransferTool/SQFormTransferTool.tsx
@@ -55,11 +55,10 @@ export default function SQFormTransferTool({
   transferProducts,
   title = 'Standard Transfer Modal',
   muiGridProps = {},
-  onTransfer = alert, // TODO this placeholder alert will be replaced in SC3-1811
+  onTransfer,
 }: SQFormTransferToolProps): React.ReactElement {
   const initialValues = getInitialValues(transferProducts);
 
-  // TODO Transfer: SC3-1811 transfers will be handled via consumer supplied callback. SC3-1811
   return (
     <Formik
       initialValues={initialValues}

--- a/src/components/SQFormTransferTool/Step.tsx
+++ b/src/components/SQFormTransferTool/Step.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import {ScriptedText} from 'scplus-shared-components';
 import SQFormDropdown from '../../components/fields/SQFormDropdown';
 import {useSQFormContext} from '../../../src';
-import type {Answer, Step} from './types';
+import {getIsConditionMet} from './util';
+import type {Step} from './types';
 
 type Props = {
   step: Step;
@@ -13,29 +14,6 @@ const styles = {
     paddingBottom: '16px',
   },
 };
-
-function checkAnswer(answer: Answer, values: Record<string, number | ''>) {
-  return values[answer.questionId] === answer.answerId;
-}
-
-function getIsConditionMet(
-  condition: Step['condition'],
-  values: Record<string, number | ''>
-) {
-  if (condition === null) {
-    return true;
-  }
-
-  const {logicalOperator, answers} = condition;
-
-  if (logicalOperator === 'and') {
-    return answers.every((answer) => checkAnswer(answer, values));
-  }
-
-  if (logicalOperator === 'or') {
-    return answers.some((answer) => checkAnswer(answer, values));
-  }
-}
 
 export default function StepRendering({
   step,

--- a/src/components/SQFormTransferTool/types.ts
+++ b/src/components/SQFormTransferTool/types.ts
@@ -45,6 +45,19 @@ export type TransferProduct = {
   steps: Step[];
 };
 
-export type OnTransfer = (msg: string) => void; // TODO this type will be defined in SC3-1811
+export type CallBackData = {
+  /** the id of the transferproduct for which the transfer button was clicked */
+  productID: TransferProduct['productID'];
+  /** number provided for transfer */
+  transferLine: string | null;
+  /** An array of form values, in the same form that the step's conditions are supplied with
+   * While the questions Ids should be globally unique, but do include questions from all
+   * produducts.
+   */
+  questionAnswers: Array<{questionId: number; answerId: number | null}>;
+  // TODO We will also include a log of opened panels
+};
+
+export type OnTransfer = (callBackData: CallBackData) => void;
 
 export type FormValues = Record<string, number | ''>;

--- a/src/components/SQFormTransferTool/util.tsx
+++ b/src/components/SQFormTransferTool/util.tsx
@@ -1,0 +1,24 @@
+import type {Answer, FormValues, Step} from './types';
+
+export function checkAnswer(answer: Answer, values: FormValues) {
+  return values[answer.questionId] === answer.answerId;
+}
+
+export function getIsConditionMet(
+  condition: Step['condition'],
+  values: FormValues
+) {
+  if (condition === null) {
+    return true;
+  }
+
+  const {logicalOperator, answers} = condition;
+
+  if (logicalOperator === 'and') {
+    return answers.every((answer) => checkAnswer(answer, values));
+  }
+
+  if (logicalOperator === 'or') {
+    return answers.some((answer) => checkAnswer(answer, values));
+  }
+}

--- a/stories/SQFormTransferTool.stories.tsx
+++ b/stories/SQFormTransferTool.stories.tsx
@@ -3,8 +3,190 @@ import {SQFormTransferTool} from '../src';
 import {createDocsPage} from './utils/createDocsPage';
 import type {Story, Meta} from '@storybook/react';
 import type {SQFormTransferToolProps} from 'components/SQFormTransferTool/SQFormTransferTool';
+import type {
+  Step,
+  TransferProduct,
+  TransferStep,
+} from 'components/SQFormTransferTool/types';
 
 type SQFormTransferToolStory = Story<SQFormTransferToolProps>;
+
+enum MOCK_IDs {
+  QUESTION_ONE_ID,
+  QUESTION_TWO_ID,
+  QUESTION_THREE_ID,
+  QUESTION_FOUR_ID,
+  SCRIPTING_ONE_ID,
+  SCRIPTING_TWO_ID,
+  SCRIPTING_THREE_ID,
+  SCRIPTING_FOUR_ID,
+  TRANSFER_ONE_ID,
+}
+
+const questionStepOne: Step = {
+  type: 'question',
+  id: MOCK_IDs.QUESTION_ONE_ID,
+  text: 'First Question',
+  options: [
+    {
+      value: 1,
+      label: 'Yes',
+    },
+    {
+      value: 2,
+      label: 'No',
+    },
+  ],
+  condition: null,
+};
+
+const questionStepTwo: Step = {
+  type: 'question',
+  id: MOCK_IDs.QUESTION_TWO_ID,
+  text: 'Question 2',
+  options: [
+    {
+      value: 1,
+      label: 'an option',
+    },
+    {
+      value: 2,
+      label: 'another option',
+    },
+    {
+      value: 3,
+      label: 'final',
+    },
+  ],
+  condition: null,
+};
+
+const conditionExample = {
+  answers: [
+    {
+      questionId: MOCK_IDs.QUESTION_ONE_ID,
+      answerId: 2,
+    },
+    {
+      questionId: MOCK_IDs.QUESTION_TWO_ID,
+      answerId: 1,
+    },
+  ],
+};
+
+// demonstrates AND logic
+const questionStepThree: Step = {
+  type: 'question',
+  id: MOCK_IDs.QUESTION_THREE_ID,
+  text: 'Question 3',
+  options: [
+    {
+      value: 1,
+      label: 'an option',
+    },
+    {
+      value: 2,
+      label: 'another option',
+    },
+    {
+      value: 3,
+      label: 'final',
+    },
+  ],
+  condition: {
+    ...conditionExample,
+    logicalOperator: 'and',
+  },
+};
+
+// demonstrates OR logic
+const questionStepFour: Step = {
+  type: 'question',
+  id: MOCK_IDs.QUESTION_FOUR_ID,
+  text: 'Question 4',
+  options: [
+    {
+      value: 1,
+      label: 'an option',
+    },
+    {
+      value: 2,
+      label: 'another option',
+    },
+    {
+      value: 3,
+      label: 'final',
+    },
+  ],
+  condition: {
+    ...conditionExample,
+    logicalOperator: 'or',
+  },
+};
+
+const stepScriptOne: Step = {
+  type: 'scripting',
+  id: MOCK_IDs.SCRIPTING_ONE_ID,
+  text: 'Question 3 demonstrates AND logic, pick no for question one AND "an option" for question two',
+  options: null,
+  condition: null,
+};
+
+const stepScriptTwo: Step = {
+  ...stepScriptOne,
+  id: MOCK_IDs.SCRIPTING_TWO_ID,
+  text: 'Question 4 demonstrates OR logic, pick either "no" for question one OR "an option for question two',
+};
+
+const stepScriptThree: Step = {
+  ...stepScriptOne,
+  id: MOCK_IDs.SCRIPTING_THREE_ID,
+  text: 'The transfer button can also depend on question answers, select "Yes" for question 1',
+};
+
+const stepScriptFour: Step = {
+  ...stepScriptOne,
+  id: MOCK_IDs.SCRIPTING_FOUR_ID,
+  text: 'Scripting steps are also conditional, this script is shown on the same condition that enables question 4',
+  condition: questionStepFour.condition,
+};
+
+const stepTransfer: TransferStep = {
+  type: 'transfer',
+  id: MOCK_IDs.TRANSFER_ONE_ID,
+  text: null,
+  options: null,
+  condition: {
+    logicalOperator: 'or',
+    answers: [
+      {
+        questionId: MOCK_IDs.QUESTION_ONE_ID,
+        answerId: 1,
+      },
+    ],
+  },
+};
+
+const conditionalMock: TransferProduct = {
+  productID: 222,
+  productTag: 'Product Tag',
+  // Note the product name and transfer button text have to share space
+  productDisplayName: 'Conditional Example',
+  modalLinkText: `Transfer to DIV AB`,
+  transferLine: '7777777777',
+  enabled: true,
+  steps: [
+    stepTransfer,
+    questionStepOne,
+    questionStepTwo,
+    stepScriptOne,
+    questionStepThree,
+    stepScriptTwo,
+    questionStepFour,
+    stepScriptThree,
+    stepScriptFour,
+  ],
+};
 
 function getMockData(
   indexes: number[] = [0]
@@ -25,15 +207,15 @@ function getMockData(
         condition: {
           logicalOperator: 'and',
           answers: [
-            {questionId: 1, answerId: 2},
-            {questionId: 2, answerId: 2},
-            {questionId: 3, answerId: 2},
+            {questionId: MOCK_IDs.QUESTION_ONE_ID, answerId: 2},
+            {questionId: MOCK_IDs.QUESTION_TWO_ID, answerId: 2},
+            {questionId: MOCK_IDs.QUESTION_THREE_ID, answerId: 2},
           ],
         },
       },
       {
         type: 'question',
-        id: 2 + idx,
+        id: MOCK_IDs.QUESTION_ONE_ID + idx,
         text: 'First Question',
         options: [
           {
@@ -110,6 +292,7 @@ const defaultArgs = {
   isOpen: false,
   transferProducts: getMockData([1, 2]),
   isLoading: false,
+  onTransfer: console.log,
 };
 
 const Template: SQFormTransferToolStory = (args): React.ReactElement => {
@@ -132,10 +315,10 @@ WithDisabled.args = {
   transferProducts: getMockData([2, 7, 1]),
 };
 
-export const WithScriptingCondition = Template.bind({});
-WithScriptingCondition.args = {
+export const WithConditions = Template.bind({});
+WithConditions.args = {
   ...defaultArgs,
-  transferProducts: getMockData([0, 2]),
+  transferProducts: [conditionalMock],
 };
 
 export const IsLoading = Template.bind({});


### PR DESCRIPTION
The loom tells almost all https://www.loom.com/share/3bbf5a8effff4f4a98d5ad6cea23ba7c?sid=800f3080-1a3e-41bd-a1ea-20e1c7365337

Additionally: 
1. the spacing issue I mention is resolved on epic/version-11, it is an issue with dropdown that is fixed.
2. The data contract on transfer is a bit shaky. Please review it a bit extra. Since this is going to be just between the consumer and this component we have some flex on how to make it work. There was not a strict requirement provided.


Here is the screen shot of the data being logged out to the console on transfer click: 
<img width="701" alt="image" src="https://github.com/SelectQuoteLabs/SQForm/assets/2816261/48218007-31b4-4c48-a42f-9a4282ea3581">


and on save / close (more work for this on the next PR)
<img width="933" alt="image" src="https://github.com/SelectQuoteLabs/SQForm/assets/2816261/ca4cda58-ae06-43da-9c19-ccc680b46816">


