### PR TITLE
feat: 🎸 adds the viewed products ids to callbacks

### DIFF
--- a/src/components/SQFormTransferTool/AccordionBody.tsx
+++ b/src/components/SQFormTransferTool/AccordionBody.tsx
@@ -7,32 +7,18 @@ import {
 } from 'scplus-shared-components';
 import Step from './Step';
 import {useSQFormContext} from '../../../src';
-import {getIsConditionMet} from './util';
+import {getIsConditionMet, transformForm} from './util';
 import type {
   OnTransfer,
   TransferProduct,
   FormValues,
-  CallBackData,
+  FormContext,
 } from './types';
 
 export type AccordionBodyProps = {
   transferProduct: TransferProduct;
   onTransfer: OnTransfer;
 };
-
-/**
- * Transforms the form values into a more friendly format. Specifically the
- * same form that the step condition uses to define questions and answers
- * with the exception that the value can be null, representing an empty value
- */
-function transformValues(values: FormValues): CallBackData['questionAnswers'] {
-  return Object.entries(values).map(([key, value]) => {
-    return {
-      questionId: Number(key),
-      answerId: value === '' ? null : Number(value),
-    };
-  });
-}
 
 function getIsTransferConditionMet(
   transferProduct: TransferProduct,
@@ -56,19 +42,16 @@ export default function AccordionBody({
   onTransfer,
 }: AccordionBodyProps): React.ReactElement {
   const {productDisplayName, modalLinkText} = transferProduct;
-  const {values} = useSQFormContext<FormValues>();
+  const {values} = useSQFormContext<FormContext>();
 
   function handleTransfer() {
-    const questionAnswers = transformValues(values);
     const {productID, transferLine} = transferProduct;
-    // TODO we will also include a log of open panels
-
-    onTransfer({transferLine, questionAnswers, productID});
+    onTransfer({transferLine, productID, ...transformForm(values)});
   }
 
   const isTransferConditionMet = getIsTransferConditionMet(
     transferProduct,
-    values
+    values.questionValues
   );
 
   const tooltip = isTransferConditionMet ? modalLinkText : 'Condition Not Met';

--- a/src/components/SQFormTransferTool/DialogInner.tsx
+++ b/src/components/SQFormTransferTool/DialogInner.tsx
@@ -140,7 +140,7 @@ function DialogInner({
       onClose={noop}
     >
       <Form>
-        <DialogTitle sx={classes.title}>
+        <DialogTitle sx={classes.title} component="div">
           <Typography variant="h5">{title}</Typography>
         </DialogTitle>
         <DialogContent

--- a/src/components/SQFormTransferTool/DialogInner.tsx
+++ b/src/components/SQFormTransferTool/DialogInner.tsx
@@ -38,6 +38,8 @@ export type DialogInnerProps = {
   helperText?: string;
   /** helper text type to pass to SQFormHelperText component */
   helperTextType?: 'fail' | 'error' | 'valid';
+  /** loading state used to determine if we should show the footer */
+  isLoading: boolean;
 };
 
 /*
@@ -105,6 +107,7 @@ function DialogInner({
   muiGridProps,
   helperText,
   helperTextType = 'error',
+  isLoading,
 }: DialogInnerProps): React.ReactElement {
   const theme = useTheme();
   const classes = useClasses(theme);
@@ -138,6 +141,7 @@ function DialogInner({
       open={isOpen}
       TransitionComponent={Transition}
       onClose={noop}
+      fullWidth={true}
     >
       <Form>
         <DialogTitle sx={classes.title} component="div">
@@ -160,18 +164,20 @@ function DialogInner({
             {children}
           </Grid>
         </DialogContent>
-        <DialogActions sx={classes.primaryAction}>
-          <>
-            {helperText && renderHelperText()}
-            <SQFormButton
-              title={saveButtonText}
-              isDisabled={isSaveButtonDisabled}
-              shouldRequireFieldUpdates={shouldRequireFieldUpdates}
-            >
-              {saveButtonText}
-            </SQFormButton>
-          </>
-        </DialogActions>
+        {!isLoading ? (
+          <DialogActions sx={classes.primaryAction}>
+            <>
+              {helperText && renderHelperText()}
+              <SQFormButton
+                title={saveButtonText}
+                isDisabled={isSaveButtonDisabled}
+                shouldRequireFieldUpdates={shouldRequireFieldUpdates}
+              >
+                {saveButtonText}
+              </SQFormButton>
+            </>
+          </DialogActions>
+        ) : null}
       </Form>
     </Dialog>
   );

--- a/src/components/SQFormTransferTool/SQFormTransferProductPanels.tsx
+++ b/src/components/SQFormTransferTool/SQFormTransferProductPanels.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import {Box} from '@mui/material';
 import {Accordion} from 'scplus-shared-components';
 import AccordionBody from './AccordionBody';
+import {useSQFormContext} from '../../index';
 import type {AccordionPanelType} from 'scplus-shared-components';
-import type {TransferProduct, OnTransfer} from './types';
+import type {TransferProduct, OnTransfer, FormContext} from './types';
 
 export type SQFormTransferProductPanelsProps = {
   transferProducts: TransferProduct[];
@@ -12,7 +13,8 @@ export type SQFormTransferProductPanelsProps = {
 
 function getPanels(
   transferProducts: TransferProduct[],
-  onTransfer: OnTransfer
+  onTransfer: OnTransfer,
+  onPanelClick: (id: TransferProduct['productID']) => void
 ): AccordionPanelType[] {
   if (!transferProducts?.length) {
     return [];
@@ -32,6 +34,7 @@ function getPanels(
       name: `${productID}`,
       title: productDisplayName,
       isDisabled: !enabled,
+      onClick: () => onPanelClick(transferProduct.productID),
     };
   });
 }
@@ -40,7 +43,17 @@ export default function SQFormTransferProductPanels({
   transferProducts,
   onTransfer,
 }: SQFormTransferProductPanelsProps): React.ReactElement | null {
-  const panels = getPanels(transferProducts, onTransfer);
+  const panels = getPanels(
+    transferProducts,
+    onTransfer,
+    updateViewedProductIDs
+  );
+  const {setFieldValue, values: context} = useSQFormContext<FormContext>();
+
+  function updateViewedProductIDs(newId: TransferProduct['productID']) {
+    const viewedIds = context.viewedProductIDs;
+    setFieldValue('viewedProductIDs', [...new Set([...viewedIds, newId])]);
+  }
 
   return (
     <Box

--- a/src/components/SQFormTransferTool/SQFormTransferTool.tsx
+++ b/src/components/SQFormTransferTool/SQFormTransferTool.tsx
@@ -83,6 +83,7 @@ export default function SQFormTransferTool({
         maxWidth={'sm'}
         title={title}
         muiGridProps={muiGridProps}
+        isLoading={isLoading}
       >
         <>
           {isLoading ? (

--- a/src/components/SQFormTransferTool/Step.tsx
+++ b/src/components/SQFormTransferTool/Step.tsx
@@ -3,7 +3,7 @@ import {ScriptedText} from 'scplus-shared-components';
 import SQFormDropdown from '../../components/fields/SQFormDropdown';
 import {useSQFormContext} from '../../../src';
 import {getIsConditionMet} from './util';
-import type {Step} from './types';
+import type {FormContext, Step} from './types';
 
 type Props = {
   step: Step;
@@ -19,14 +19,14 @@ export default function StepRendering({
   step,
 }: Props): React.ReactElement | null {
   const {id, type, text, options, condition} = step;
-  const {values} = useSQFormContext<Record<string, number | ''>>();
-  const isConditionMet = getIsConditionMet(condition, values);
+  const {values: context} = useSQFormContext<FormContext>();
+  const isConditionMet = getIsConditionMet(condition, context.questionValues);
 
   if (type === 'question') {
     return (
       <SQFormDropdown
         label={text}
-        name={`${id}`}
+        name={`questionValues.${id}`}
         // For question steps, if the condition is not met we should disable the dropdown
         isDisabled={!isConditionMet}
         displayEmpty={true}

--- a/src/components/SQFormTransferTool/types.ts
+++ b/src/components/SQFormTransferTool/types.ts
@@ -45,19 +45,30 @@ export type TransferProduct = {
   steps: Step[];
 };
 
-export type CallBackData = {
-  /** the id of the transferproduct for which the transfer button was clicked */
-  productID: TransferProduct['productID'];
-  /** number provided for transfer */
-  transferLine: string | null;
+type OnSaveCallBackData = {
   /** An array of form values, in the same form that the step's conditions are supplied with
    * While the questions Ids should be globally unique, but do include questions from all
    * produducts.
    */
   questionAnswers: Array<{questionId: number; answerId: number | null}>;
-  // TODO We will also include a log of opened panels
+  /** Opened product panel ids, all products are initially not expanded */
+  viewedProductIDs: Array<TransferProduct['productID']>;
 };
 
-export type OnTransfer = (callBackData: CallBackData) => void;
+type TransferCallBackData = OnSaveCallBackData & {
+  /** the id of the transferproduct for which the transfer button was clicked */
+  productID: TransferProduct['productID'];
+  /** number provided for transfer */
+  transferLine: string | null;
+};
+
+export type CallBackData = OnSaveCallBackData | TransferCallBackData;
+
+export type OnTransfer = (callBackData: TransferCallBackData) => void;
+export type OnSave = (callBackData: OnSaveCallBackData) => void;
 
 export type FormValues = Record<string, number | ''>;
+export type FormContext = {
+  viewedProductIDs: number[];
+  questionValues: FormValues;
+};

--- a/src/components/SQFormTransferTool/util.tsx
+++ b/src/components/SQFormTransferTool/util.tsx
@@ -1,4 +1,10 @@
-import type {Answer, FormValues, Step} from './types';
+import type {
+  Answer,
+  FormValues,
+  Step,
+  FormContext,
+  CallBackData,
+} from './types';
 
 export function checkAnswer(answer: Answer, values: FormValues) {
   return values[answer.questionId] === answer.answerId;
@@ -21,4 +27,24 @@ export function getIsConditionMet(
   if (logicalOperator === 'or') {
     return answers.some((answer) => checkAnswer(answer, values));
   }
+}
+
+/**
+ * Transforms the form values into a more friendly format. Specifically the
+ * same form that the step condition uses to define questions and answers
+ * with the exception that the value can be null, representing an empty value
+ */
+export function transformForm(
+  form: FormContext
+): Pick<CallBackData, 'viewedProductIDs' | 'questionAnswers'> {
+  const {questionValues, viewedProductIDs} = form;
+
+  const questionAnswers = Object.entries(questionValues).map(([key, value]) => {
+    return {
+      questionId: Number(key),
+      answerId: value === '' ? null : Number(value),
+    };
+  });
+
+  return {questionAnswers, viewedProductIDs};
 }

--- a/stories/SQFormTransferTool.stories.tsx
+++ b/stories/SQFormTransferTool.stories.tsx
@@ -204,14 +204,7 @@ function getMockData(
         id: 1 + idx,
         text: null,
         options: null,
-        condition: {
-          logicalOperator: 'and',
-          answers: [
-            {questionId: MOCK_IDs.QUESTION_ONE_ID, answerId: 2},
-            {questionId: MOCK_IDs.QUESTION_TWO_ID, answerId: 2},
-            {questionId: MOCK_IDs.QUESTION_THREE_ID, answerId: 2},
-          ],
-        },
+        condition: null,
       },
       {
         type: 'question',
@@ -234,10 +227,7 @@ function getMockData(
         id: 3 + idx,
         text: 'This is the scripting',
         options: null,
-        condition: {
-          logicalOperator: 'and',
-          answers: [{questionId: 1, answerId: 2}],
-        },
+        condition: null,
       },
       {
         type: 'question',
@@ -257,19 +247,7 @@ function getMockData(
             label: 'final',
           },
         ],
-        condition: {
-          logicalOperator: `or`,
-          answers: [
-            {
-              questionId: 1,
-              answerId: 2,
-            },
-            {
-              questionId: 3,
-              answerId: 1,
-            },
-          ],
-        },
+        condition: null,
       },
     ],
   }));
@@ -312,18 +290,21 @@ Default.args = defaultArgs;
 export const WithDisabled = Template.bind({});
 WithDisabled.args = {
   ...defaultArgs,
+  title: 'With Disabled',
   transferProducts: getMockData([2, 7, 1]),
 };
 
 export const WithConditions = Template.bind({});
 WithConditions.args = {
   ...defaultArgs,
+  title: 'With Conditions',
   transferProducts: [conditionalMock],
 };
 
 export const IsLoading = Template.bind({});
 IsLoading.args = {
   ...defaultArgs,
+  title: 'Is Loading example',
   isLoading: true,
 };
 


### PR DESCRIPTION
Once again the loom is very informative:[ Informative Loom ](https://www.loom.com/share/73851796b63b41d686ad44a7f2d6ca97?sid=08b518cc-7f41-4541-920c-9f30882add94)

Adds to both onSave and onTransfer Callbacks a list of ids for products whose panels were opened ([watch the loom](https://www.loom.com/share/73851796b63b41d686ad44a7f2d6ca97?sid=08b518cc-7f41-4541-920c-9f30882add94)).

[Thanks](https://www.loom.com/share/73851796b63b41d686ad44a7f2d6ca97?sid=08b518cc-7f41-4541-920c-9f30882add94)

**NOTE: The loom didn't capture the console. I will be evaluating and getting that info to this somehow. Either a new loom or an addendum**