### PR TITLE
SC3-1863 formik helpers & loading msg

### DIFF
--- a/src/components/SQFormTransferTool/AccordionBody.tsx
+++ b/src/components/SQFormTransferTool/AccordionBody.tsx
@@ -42,11 +42,17 @@ export default function AccordionBody({
   onTransfer,
 }: AccordionBodyProps): React.ReactElement {
   const {productDisplayName, modalLinkText} = transferProduct;
-  const {values} = useSQFormContext<FormContext>();
+  /* while the name formik Helpers is slightly misleading as it contains more
+   * than that, it is at least safe given that the rest is inclusive of the helpers
+   */
+  const {values, ...formikHelpers} = useSQFormContext<FormContext>();
 
   function handleTransfer() {
     const {productID, transferLine} = transferProduct;
-    onTransfer({transferLine, productID, ...transformForm(values)});
+    onTransfer(
+      {transferLine, productID, ...transformForm(values)},
+      formikHelpers
+    );
   }
 
   const isTransferConditionMet = getIsTransferConditionMet(

--- a/src/components/SQFormTransferTool/SQFormTransferTool.tsx
+++ b/src/components/SQFormTransferTool/SQFormTransferTool.tsx
@@ -12,6 +12,7 @@ import type {
   FormContext,
   OnSave,
 } from './types';
+import type {FormikHelpers} from 'formik';
 
 export type SQFormTransferToolProps = {
   /** boolean to indicate if the modal should show a loading indicator */
@@ -28,6 +29,8 @@ export type SQFormTransferToolProps = {
   onTransfer: OnTransfer;
   /** Any prop from https://material-ui.com/api/grid applied to contents of modal */
   muiGridProps?: GridProps;
+  /** Loading Message to be shown under the loading spinner when isLoading is true*/
+  loadingMessage?: string;
 };
 
 /** Given an array of TransferProduct produce initial values object
@@ -61,11 +64,15 @@ export default function SQFormTransferTool({
   title = 'Standard Transfer Modal',
   muiGridProps = {},
   onTransfer,
+  loadingMessage = 'Loading...',
 }: SQFormTransferToolProps): React.ReactElement {
   const initialValues = getInitialValues(transferProducts);
 
-  function handleSave(values: FormContext): void {
-    onSave({...transformForm(values)});
+  function handleSave(
+    values: FormContext,
+    formikHelpers: FormikHelpers<FormContext>
+  ): void {
+    onSave({...transformForm(values)}, formikHelpers);
   }
 
   return (
@@ -87,7 +94,7 @@ export default function SQFormTransferTool({
       >
         <>
           {isLoading ? (
-            <LoadingSpinner message="Loading transfer options" />
+            <LoadingSpinner message={loadingMessage} />
           ) : (
             <SQFormTransferProductPanels
               transferProducts={transferProducts}

--- a/src/components/SQFormTransferTool/types.ts
+++ b/src/components/SQFormTransferTool/types.ts
@@ -1,3 +1,5 @@
+import type {FormikHelpers, FormikValues} from 'formik';
+
 export type Answer = {
   questionId: number;
   answerId: number;
@@ -64,11 +66,17 @@ type TransferCallBackData = OnSaveCallBackData & {
 
 export type CallBackData = OnSaveCallBackData | TransferCallBackData;
 
-export type OnTransfer = (callBackData: TransferCallBackData) => void;
-export type OnSave = (callBackData: OnSaveCallBackData) => void;
+export type OnTransfer = (
+  callBackData: TransferCallBackData,
+  formikHelpers: FormikHelpers<FormContext>
+) => void;
+export type OnSave = (
+  callBackData: OnSaveCallBackData,
+  formikHelpers: FormikHelpers<FormContext>
+) => void;
 
 export type FormValues = Record<string, number | ''>;
-export type FormContext = {
+export type FormContext = FormikValues & {
   viewedProductIDs: number[];
   questionValues: FormValues;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,6 @@ export type {
   SQFormGuidedWorkflowTaskModuleProps,
   SQFormGuidedWorkflowContext,
 } from './components/SQFormGuidedWorkflow/Types';
-
 // Other Types
 export type {default as BaseFieldProps} from './types/BaseFieldProps';
 export type {default as SQFormOption, SQFormOptionValue} from './types/Option';

--- a/stories/SQFormTransferTool.stories.tsx
+++ b/stories/SQFormTransferTool.stories.tsx
@@ -299,6 +299,7 @@ WithConditions.args = {
   ...defaultArgs,
   title: 'With Conditions',
   transferProducts: [conditionalMock],
+  loadingMessage: 'Loading Conditional Example...',
 };
 
 export const IsLoading = Template.bind({});


### PR DESCRIPTION
Loom should tell all https://www.loom.com/share/fb1ba4d5ceac4bf2afc43af3e9f754d6?sid=bda677b3-78e3-4150-9486-8d6e9019dbc1

Some basic clean up from consuming on the branch `epic/mui5` for senior. 

Added formik helpers to the callbacks so that we can reset the form (to avoid the conditional rendering of modals, unless that is your bag, then that works too).

Also added a prop for overriding the loading message. 