### PR TITLE
fix: 🐛 Fields scroll behind form modal header

### DIFF
--- a/src/components/SQFormDialog/SQFormDialogInner.tsx
+++ b/src/components/SQFormDialog/SQFormDialogInner.tsx
@@ -112,6 +112,7 @@ const useClasses = (theme: Theme) => ({
     borderBottom: `1px solid #B3B3B3`,
     padding: '12px 16px',
     height: '49px',
+    zIndex: 1,
   },
   action: actionStyles(theme),
   primaryAction: {

--- a/src/components/SQFormDialog/SQFormDialogInner.tsx
+++ b/src/components/SQFormDialog/SQFormDialogInner.tsx
@@ -112,6 +112,7 @@ const useClasses = (theme: Theme) => ({
     borderBottom: `1px solid #B3B3B3`,
     padding: '12px 16px',
     height: '49px',
+    zIndex:1
   },
   action: actionStyles(theme),
   primaryAction: {

--- a/src/components/SQFormDialog/SQFormDialogInner.tsx
+++ b/src/components/SQFormDialog/SQFormDialogInner.tsx
@@ -112,7 +112,7 @@ const useClasses = (theme: Theme) => ({
     borderBottom: `1px solid #B3B3B3`,
     padding: '12px 16px',
     height: '49px',
-    zIndex:1
+    zIndex: 1,
   },
   action: actionStyles(theme),
   primaryAction: {

--- a/src/components/SQFormDialog/SQFormDialogInner.tsx
+++ b/src/components/SQFormDialog/SQFormDialogInner.tsx
@@ -112,7 +112,6 @@ const useClasses = (theme: Theme) => ({
     borderBottom: `1px solid #B3B3B3`,
     padding: '12px 16px',
     height: '49px',
-    zIndex: 1,
   },
   action: actionStyles(theme),
   primaryAction: {


### PR DESCRIPTION
Fields were going behind from modal header

When viewing a form modal, when you scroll a list of fields, the fields are scrolling on top of the header section.

AC:
When you scroll on a form modal the fields do not show in the header

Loom: https://www.loom.com/share/cc4810764e18427190b28f9cb84317d2?sid=900f374e-e0a9-405b-8363-303fec387d8a

✅ Closes: #920