### PR TITLE
feat: 🎸 SQFormDatePicker styles

### DIFF
--- a/src/components/fields/SQFormDatePicker/SQFormDatePicker.tsx
+++ b/src/components/fields/SQFormDatePicker/SQFormDatePicker.tsx
@@ -52,7 +52,7 @@ function SQFormDatePicker({
   size = 'auto',
   isDisabled = false,
   displayHelperText = true,
-  placeholder = '',
+  placeholder = 'MM / DD / YYYY',
   onBlur,
   onChange,
   setDisabledDate,
@@ -109,13 +109,16 @@ function SQFormDatePicker({
                 variant="standard"
                 error={isFieldError}
                 fullWidth={true}
-                inputProps={{...inputProps.inputProps, ...muiTextInputProps}}
+                inputProps={{
+                  ...inputProps.inputProps,
+                  placeholder,
+                  ...muiTextInputProps,
+                }}
                 InputLabelProps={{shrink: true}}
                 FormHelperTextProps={{error: isFieldError}}
                 helperText={
                   !isDisabled && displayHelperText && HelperTextComponent
                 }
-                placeholder={placeholder}
                 onBlur={handleBlur}
                 required={isFieldRequired}
                 onClick={
@@ -123,14 +126,6 @@ function SQFormDatePicker({
                     ? toggleCalendar
                     : handleClickAway
                 }
-                sx={{
-                  '& .MuiInputBase-root.Mui-focused, & .MuiInputBase-root:hover:not(.Mui-disabled)':
-                    {
-                      '& .MuiIconButton-root': {
-                        color: 'var(--color-teal)',
-                      },
-                    },
-                }}
               />
             );
           }}

--- a/src/components/fields/SQFormDatePicker/SQFormDatePickerWithCalendarInputOnly.tsx
+++ b/src/components/fields/SQFormDatePicker/SQFormDatePickerWithCalendarInputOnly.tsx
@@ -31,7 +31,7 @@ function SQFormDatePickerWithCalendarInputOnly({
   label,
   size = 'auto',
   isDisabled = false,
-  placeholder = '',
+  placeholder,
   onBlur,
   onChange,
   setDisabledDate,

--- a/src/components/fields/SQFormDatePicker/SQFormDatePickerWithDateFNS.tsx
+++ b/src/components/fields/SQFormDatePicker/SQFormDatePickerWithDateFNS.tsx
@@ -22,7 +22,7 @@ function SQFormDatePickerWithDateFNS({
   label,
   size = 'auto',
   isDisabled = false,
-  placeholder = '',
+  placeholder = 'MM / DD / YYYY',
   onBlur,
   onChange,
   setDisabledDate,
@@ -79,11 +79,14 @@ function SQFormDatePickerWithDateFNS({
                 variant="standard"
                 error={isFieldError}
                 fullWidth={true}
-                inputProps={{...inputProps.inputProps, ...muiTextInputProps}}
+                inputProps={{
+                  ...inputProps.inputProps,
+                  placeholder,
+                  ...muiTextInputProps,
+                }}
                 InputLabelProps={{shrink: true}}
                 FormHelperTextProps={{error: isFieldError}}
                 helperText={!isDisabled && HelperTextComponent}
-                placeholder={placeholder}
                 onBlur={handleBlur}
                 required={isFieldRequired}
                 onClick={
@@ -91,14 +94,6 @@ function SQFormDatePickerWithDateFNS({
                     ? toggleCalendar
                     : handleClickAway
                 }
-                sx={{
-                  '& .MuiInputBase-root.Mui-focused, & .MuiInputBase-root:hover:not(.Mui-disabled)':
-                    {
-                      '& .MuiIconButton-root': {
-                        color: 'var(--color-teal)',
-                      },
-                    },
-                }}
               />
             );
           }}

--- a/src/components/fields/SQFormDatePicker/SQFormDateTimePicker.tsx
+++ b/src/components/fields/SQFormDatePicker/SQFormDateTimePicker.tsx
@@ -4,6 +4,7 @@ import {DateTimePicker} from '@mui/x-date-pickers';
 import {useForm} from '../../../hooks/useForm';
 import type {MarkOptional} from 'ts-essentials';
 import type {Moment} from 'moment';
+import type {InputBaseComponentProps} from '@mui/material';
 import type {BaseDateTimePickerProps} from '@mui/x-date-pickers/DateTimePicker/shared';
 import type {BaseFieldProps} from '../../../types';
 
@@ -21,6 +22,8 @@ export type SQFormDateTimePickerProps = BaseFieldProps & {
     BaseDateTimePickerProps<Moment, Moment>,
     'onChange' | 'value' | 'renderInput'
   >;
+  /** Any valid prop for MUI input field - https://material-ui.com/api/text-field/ & https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attributes */
+  muiTextInputProps?: InputBaseComponentProps;
 };
 
 function SQFormDateTimePicker({
@@ -28,10 +31,11 @@ function SQFormDateTimePicker({
   label,
   size = 'auto',
   isDisabled = false,
-  placeholder = '',
+  placeholder = 'MM / DD / YYYY HH:MM (A|P)M',
   onBlur,
   onChange,
   muiFieldProps = {},
+  muiTextInputProps = {},
 }: SQFormDateTimePickerProps): JSX.Element {
   const {
     formikField: {field, helpers},
@@ -80,10 +84,14 @@ function SQFormDateTimePicker({
                 disabled={isDisabled}
                 error={isFieldError}
                 fullWidth={true}
+                inputProps={{
+                  ...inputProps.inputProps,
+                  placeholder,
+                  ...muiTextInputProps,
+                }}
                 InputLabelProps={{shrink: true}}
                 FormHelperTextProps={{error: isFieldError}}
                 helperText={!isDisabled && HelperTextComponent}
-                placeholder={placeholder}
                 onBlur={handleBlur}
                 onClick={handleClickAway}
                 required={isFieldRequired}


### PR DESCRIPTION
Adjust SQFormDatePicker styles to match comps
✅ Closes: SSR-249

**Before**
<img width="333" alt="Screenshot 2023-10-05 at 2 58 31 PM" src="https://github.com/SelectQuoteLabs/SQForm/assets/29528409/d9f6dc21-9fe6-41c6-a8ad-526d04ebb501">
**After**
<img width="322" alt="Screenshot 2023-10-05 at 2 58 43 PM" src="https://github.com/SelectQuoteLabs/SQForm/assets/29528409/613b0415-5e0b-452c-a034-cec628bba96d">
**Before**
<img width="331" alt="Screenshot 2023-10-05 at 2 58 50 PM" src="https://github.com/SelectQuoteLabs/SQForm/assets/29528409/71e285b2-9983-4251-bda2-36e585ede642">
**After**
<img width="334" alt="Screenshot 2023-10-05 at 2 58 55 PM" src="https://github.com/SelectQuoteLabs/SQForm/assets/29528409/3c3125c2-4490-44cd-9325-2d00d0312d1c">
**Before**
<img width="342" alt="Screenshot 2023-10-05 at 2 59 08 PM" src="https://github.com/SelectQuoteLabs/SQForm/assets/29528409/785f8d2c-309e-49e6-adef-1803e41370a4">
**After**
<img width="341" alt="Screenshot 2023-10-05 at 2 59 12 PM" src="https://github.com/SelectQuoteLabs/SQForm/assets/29528409/f2521efe-c8f7-4e37-ab62-f579e3e63557">
**Before**
<img width="329" alt="Screenshot 2023-10-05 at 2 59 38 PM" src="https://github.com/SelectQuoteLabs/SQForm/assets/29528409/c1b7924b-38aa-41ee-967b-a334b8d1666b">
**After**
<img width="324" alt="Screenshot 2023-10-05 at 3 04 00 PM" src="https://github.com/SelectQuoteLabs/SQForm/assets/29528409/25a6ca3c-6001-4c18-8a0e-f625541f13b3">
