### PR TITLE
Switching to secrets.GITHUB_TOKEN vs secrets.ACTIONS_TOKEN

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -23,5 +23,5 @@ jobs:
       - run: npm run build
       - run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This is provided by github, not sure why we need a different one.